### PR TITLE
Fix raster image upload

### DIFF
--- a/src/components/BatchProcessing.vue
+++ b/src/components/BatchProcessing.vue
@@ -248,7 +248,6 @@ const handleCompareTiles = async () => {
         return fetch(`${apiBaseUrl}projects/${projectId}/images/a`, {
           method: 'PUT',
           headers: {
-            'Content-Type': 'multipart/form-data',
             Authorization: `Bearer ${token}`,
           },
           body: formData,
@@ -264,7 +263,6 @@ const handleCompareTiles = async () => {
         return fetch(`${apiBaseUrl}projects/${projectId}/images/b`, {
           method: 'PUT',
           headers: {
-            'Content-Type': 'multipart/form-data',
             Authorization: `Bearer ${token}`,
           },
           body: formData,


### PR DESCRIPTION
This pull request fixes the a/b image upload: when submitting `FormData` with `fetch`, you must not set the `Content-type` header.

When this pull request is merged, uploading a/b images for a project works, and the only thing remaining that fails is the inference calculation, due to bounding box issues.