### PR TITLE
Make sure prettier auto-save is active in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 *.suo
 *.ntvs*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
Because this repository relies on prettier for code formatting, I think it would make sense to enforce applying prettier suggestions automatically on save in VS Code, regardless of the global or user VS Code configuration.