### PR TITLE
Handles issue 27 and 32

### DIFF
--- a/src/components/BatchProcessing.vue
+++ b/src/components/BatchProcessing.vue
@@ -6,6 +6,7 @@ import searchStacApi from '../functions/search-stac-api'
 import { addStacLayer, removeStacLayer } from '../functions/add-stac-layer'
 import { generateJWT } from '../functions/generate-jwt'
 import { transformExtent } from 'ol/proj'
+import { extend, getArea } from 'ol/extent'
 
 interface SearchResult {
   id: string
@@ -43,6 +44,7 @@ const isFirstResultsOpen = ref(false)
 const isSecondResultsOpen = ref(false)
 const retryTimeout = ref<number | null>(null)
 const currentBbox = ref<number[] | undefined>(undefined)
+const currentGridExtent = ref<Extent | null>(null)
 
 const toggleAccordion = () => {
   emit('update:isOpen', !props.isOpen)
@@ -59,11 +61,21 @@ const toggleSecondResults = () => {
 }
 
 // Function to handle search results
-const handleSearchResults = async (mgrsTileId: string, bbox?: number[], settings?: any) => {
+const handleSearchResults = async (
+  mgrsTileId: string,
+  bbox?: number[],
+  settings?: any,
+  gridExtent?: Extent,
+) => {
   isLoading.value = true
   searchStatus.value = `Searching for Sentinel-2 images in tile ${mgrsTileId}...`
   currentMgrsTileId.value = mgrsTileId
   currentBbox.value = bbox
+  // Store the current grid extent for use in STAC layer positioning
+  if (gridExtent) {
+    // Store the grid extent in a ref so it can be used later
+    currentGridExtent.value = gridExtent
+  }
 
   try {
     const response = await searchStacApi(bbox, true, settings)
@@ -138,6 +150,9 @@ const handleViewOnMap = (
   tileId: string,
   isSecondAccordion: boolean = false,
 ) => {
+  // Use the stored currentGridExtent for positioning the STAC layer
+  const gridExtent = currentGridExtent.value || currentBbox.value || bounds
+
   if (isSecondAccordion) {
     if (tileId === activeTileId.value) {
       return
@@ -148,8 +163,8 @@ const handleViewOnMap = (
       secondActiveTileId.value = null
     } else {
       removeStacLayer(props.map)
-      if (bounds) {
-        addStacLayer(props.map, imageUrl, bounds)
+      if (gridExtent) {
+        addStacLayer(props.map, imageUrl, gridExtent)
         secondActiveTileId.value = tileId
       } else {
         console.error('No bounds available for this image')
@@ -164,8 +179,8 @@ const handleViewOnMap = (
       }
     } else {
       removeStacLayer(props.map)
-      if (bounds) {
-        addStacLayer(props.map, imageUrl, bounds)
+      if (gridExtent) {
+        addStacLayer(props.map, imageUrl, gridExtent)
         activeTileId.value = tileId
         if (secondActiveTileId.value === tileId) {
           secondActiveTileId.value = null
@@ -425,7 +440,6 @@ const handleCompareTiles = async () => {
           }
 
           const results = await resultsResponse.json()
-          console.log('Batch processing results:', results)
 
           projectMessage.value = {
             type: 'success',

--- a/src/components/DataCabinet.vue
+++ b/src/components/DataCabinet.vue
@@ -77,8 +77,13 @@ const handleSettingsSave = (newSettings: any) => {
 
 // Expose methods to parent components
 defineExpose({
-  handleSearchResults: (mgrsTileId: string, bbox?: number[]) =>
-    batchProcessingRef.value?.handleSearchResults(mgrsTileId, bbox, settings.value),
+  handleSearchResults: (mgrsTileId: string, bbox?: number[], currentGridExtent?: Extent) =>
+    batchProcessingRef.value?.handleSearchResults(
+      mgrsTileId,
+      bbox,
+      settings.value,
+      currentGridExtent,
+    ),
   setDrawnExtent: (extent: Extent) => batchProcessingRef.value?.setDrawnExtent(extent),
   currentMgrsTileId: batchProcessingRef.value?.currentMgrsTileId,
   handleBboxSizeWarning: (message: string) =>

--- a/src/functions/add-stac-layer.ts
+++ b/src/functions/add-stac-layer.ts
@@ -1,24 +1,21 @@
 import ImageLayer from 'ol/layer/Image'
 import ImageStatic from 'ol/source/ImageStatic'
 import { Map } from 'ol'
-import { transform } from 'ol/proj'
 import type { Extent } from 'ol/extent'
-import { transformExtent } from 'ol/proj'
 
 let currentStacLayer: ImageLayer<ImageStatic> | null = null
 let currentSecondStacLayer: ImageLayer<ImageStatic> | null = null
 
 export function addStacLayer(map: Map, imageUrl: string, extent: Extent) {
   try {
-    // Transform extent from EPSG:4326 (WGS84) to EPSG:3857 (Web Mercator)
-    const transformedExtent = transformExtent(extent, 'EPSG:4326', 'EPSG:3857')
     // Create new STAC layer
     currentStacLayer = new ImageLayer({
       source: new ImageStatic({
         url: imageUrl,
-        imageExtent: transformedExtent,
+        imageExtent: extent,
         crossOrigin: 'anonymous',
       }),
+      extent: extent,
       zIndex: 100, // Place above base layer but below S2 grid
     })
     // Set a semi-transparent background to help distinguish the tile from the base layer
@@ -26,7 +23,7 @@ export function addStacLayer(map: Map, imageUrl: string, extent: Extent) {
     // Add the new layer to the map
     map.addLayer(currentStacLayer)
     // Fit the view to the transformed extent
-    map.getView().fit(transformedExtent, {
+    map.getView().fit(extent, {
       duration: 1000,
       padding: [50, 50, 50, 50],
     })

--- a/src/functions/search-stac-api.ts
+++ b/src/functions/search-stac-api.ts
@@ -80,7 +80,6 @@ export default async function searchStacApi(
   resetSearch = true,
   settings?: SearchSettings,
 ): Promise<SearchResponse | undefined> {
-  console.log('settings', settings)
   // Use provided settings or fall back to DOM elements
   const startDate = settings?.startDate ? convertToRFC3339(settings.startDate) : ''
   const endDate = settings?.endDate ? convertToRFC3339(settings.endDate) : ''

--- a/src/layers/S2-Grid-Layer.ts
+++ b/src/layers/S2-Grid-Layer.ts
@@ -10,6 +10,7 @@ import VectorLayer from 'ol/layer/Vector.js'
 import { transformExtent } from 'ol/proj'
 import VectorSource from 'ol/source/Vector.js'
 import { getArea } from 'ol/sphere'
+import { getArea as getAreaExtent } from 'ol/extent'
 import { Fill, Stroke, Style } from 'ol/style.js'
 import type { Ref } from 'vue'
 import type DataCabinet from '../components/DataCabinet.vue'
@@ -122,7 +123,6 @@ export default function createS2GridLayer(
       if (geometry) {
         const extent = geometry.getExtent()
         currentGridExtent = extent // Store the current grid extent
-
         // Calculate the bounding box based on area values
         const bboxExtent = calculateBoundingBox(extent, areaValues)
 
@@ -208,7 +208,7 @@ export default function createS2GridLayer(
 
         // Call the search function through the ref and open the Batch Processing accordion
         if (dataCabinetRef.value?.handleSearchResults) {
-          dataCabinetRef.value.handleSearchResults(mgrsTileId, bbox)
+          dataCabinetRef.value.handleSearchResults(mgrsTileId, bbox, currentGridExtent)
           // Open the Batch Processing accordion
           if (dataCabinetRef.value?.handleBatchProcessingToggle) {
             dataCabinetRef.value.handleBatchProcessingToggle(true)
@@ -263,7 +263,7 @@ export default function createS2GridLayer(
               }
               if (!isWithinExtent) {
                 showWarning(
-                  'Bounding box is outside the selected grid area. Using last valid state.',
+                  'Running inference across Sentinel 2 tile boundaries is not yet supported. Move your bbox to the selected tile, or select a different tile.',
                 )
               }
               warningShown = true


### PR DESCRIPTION
Issue 27 - Display a warning when the user moves the box outside of the grid area

- I see this is working in the deployed app but updated the message to reflect what is in the issue.

Issue 32 - Preview image not aligned to base layer

- Using the bounds of the selected s2 tile to set the bounds of the image so that it now aligns with the basemap for when the S2 Image is smaller than the bounds of the tile.