### PR TITLE
New tile search auto expand/collapse logic

### DIFF
--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -33,6 +33,19 @@ const { currentBbox, hasMore, isLoading, searchResults, searchStatus } = useSear
 const { currentGridExtent, currentMgrsTileId, activeTileId, secondActiveTileId } =
   useAreaOfInterest()
 
+watch(drawnExtent, (newValue) => {
+  if (newValue) {
+    isFirstResultsOpen.value = true
+  }
+})
+
+watch(activeTileId, (newValue) => {
+  if (newValue && !secondActiveTileId.value) {
+    isFirstResultsOpen.value = false
+    isSecondResultsOpen.value = true
+  }
+})
+
 const isOpen = ref(props.isOpen)
 const processingMode = ref(props.processingMode)
 watch(
@@ -57,12 +70,10 @@ const toggleAccordion = () => {
 
 const toggleFirstResults = () => {
   isFirstResultsOpen.value = !isFirstResultsOpen.value
-  isSecondResultsOpen.value = !isFirstResultsOpen.value // Close second results if first is opened
 }
 
 const toggleSecondResults = () => {
   isSecondResultsOpen.value = !isSecondResultsOpen.value
-  isFirstResultsOpen.value = !isSecondResultsOpen.value // Close first results if second is opened
 }
 
 // Function to load more results


### PR DESCRIPTION
Auto-expands the first tile search after map click, i.e. when the bounding box is available. Auto-collapses the first tile after a selection has been made, if there is no second tile selected yet.

This replaces the current logic, where tile 1 search was always collapsed when tile 2 search was expanded, and vice versa.