### PR TITLE
Fix and improve hash handling

### DIFF
--- a/src/components/DataCabinet.vue
+++ b/src/components/DataCabinet.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Map } from 'ol'
 import { fromExtent } from 'ol/geom/Polygon'
 import { ref, watch } from 'vue'
 import ProcessingPanel from './ProcessingPanel.vue'
@@ -9,22 +8,19 @@ import { useSearch } from '../composables/useSearch'
 import { getArea } from 'ol/sphere'
 import { useAreaOfInterest } from '../composables/useAreaOfInterest'
 import { mdiCog, mdiInformation, mdiMagnify } from '@mdi/js'
-
-const props = defineProps<{
-  map: Map
-  areaValues: { min_area_km2: number; max_area_km2: number }
-  dataCabinetRef: any
-}>()
+import { useProcessingMode } from '../composables/useProcessingMode'
+import { useMap } from '../composables/useMap'
 
 const emit = defineEmits<{
   (e: 'updateGeoJSONResults', results: any[]): void
 }>()
 
+const { map, areaValues } = useMap()
 const { currentBbox, handleSearchResults } = useSearch()
 const { drawnExtent, currentMgrsTileId, triggerTileSelection, activeTileId, secondActiveTileId } =
   useAreaOfInterest()
 
-const processingMode = ref<'smallAreaProcessing' | 'batchProcessing' | null>('smallAreaProcessing')
+const { processingMode } = useProcessingMode()
 const ftwAboutDialogShown = localStorage.getItem('ftw-about-dialog-shown') !== 'true'
 const aboutDialog = ref(ftwAboutDialogShown)
 const dontShowAgain = ref(!ftwAboutDialogShown)
@@ -63,14 +59,13 @@ const loadSettingsFromStorage = () => {
 
 const settings = ref(loadSettingsFromStorage())
 
-const handleProcessingToggle = (isOpen: boolean) => {
+watch(drawnExtent, (newValue) => {
   if (!currentBbox.value) return
-  processingMode.value = isOpen
-    ? drawnExtent.value && getArea(fromExtent(drawnExtent.value)) < 200000000 // 200 km² threshold
+  processingMode.value =
+    newValue && getArea(fromExtent(newValue)) < 200000000 // 200 km² threshold
       ? 'smallAreaProcessing'
       : 'batchProcessing'
-    : null
-}
+})
 
 const handleSettingsClick = () => {
   isSettingsModalOpen.value = true
@@ -89,7 +84,7 @@ const handleSettingsSave = (newSettings: any) => {
 // Handle tile selection from search modal
 const handleTileSelected = (tileName: string) => {
   // Find the tile feature on the map and trigger the tile selection
-  const layers = props.map.getLayers().getArray()
+  const layers = map.value!.getLayers().getArray()
   const s2GridLayer = layers.find(
     (layer) =>
       layer.get('name') === 's2-grid' ||
@@ -102,13 +97,7 @@ const handleTileSelected = (tileName: string) => {
     const targetFeature = features.find((f: any) => f.get('Name') === tileName)
 
     if (targetFeature) {
-      triggerTileSelection(
-        props.map,
-        tileName,
-        targetFeature,
-        props.areaValues,
-        handleSearchResults,
-      )
+      triggerTileSelection(map.value!, tileName, areaValues.value!, handleSearchResults)
     }
   }
 }
@@ -167,7 +156,7 @@ const handleSetSecondActiveTileId = (tileId: string) => {
 // Handle combined tile and bbox selection from search modal
 const handleTileAndBboxSelected = (tileName: string, bbox?: number[]) => {
   // Find the tile feature on the map and trigger the tile selection with bbox
-  const layers = props.map.getLayers().getArray()
+  const layers = map.value!.getLayers().getArray()
   const s2GridLayer = layers.find(
     (layer) =>
       layer.get('name') === 's2-grid' ||
@@ -181,22 +170,10 @@ const handleTileAndBboxSelected = (tileName: string, bbox?: number[]) => {
 
     if (targetFeature) {
       // Use the updated triggerTileSelection with bbox parameter
-      triggerTileSelection(
-        props.map,
-        tileName,
-        props.dataCabinetRef,
-        props.areaValues,
-        handleSearchResults,
-        bbox,
-      )
+      triggerTileSelection(map.value!, tileName, areaValues.value!, handleSearchResults, bbox)
     }
   }
 }
-
-// Expose methods to parent components
-defineExpose({
-  handleProcessingToggle: (isOpen: boolean) => handleProcessingToggle(isOpen),
-})
 </script>
 
 <template>
@@ -226,10 +203,8 @@ defineExpose({
       ></v-btn>
     </div>
     <ProcessingPanel
-      v-if="props.map"
+      v-if="map"
       is-open
-      :map="props.map"
-      :processing-mode="processingMode"
       @updateGeoJSONResults="
         (results: any[]) => {
           emit('updateGeoJSONResults', results)
@@ -248,8 +223,6 @@ defineExpose({
     <!-- Search Modal -->
     <SearchModal
       :is-open="isSearchModalOpen"
-      :map="props.map"
-      :area-values="props.areaValues"
       @update:is-open="isSearchModalOpen = $event"
       @tile-selected="handleTileSelected"
       @bbox-selected="handleBboxSelected"

--- a/src/components/MapComponent.vue
+++ b/src/components/MapComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, shallowRef } from 'vue'
+import { ref, onMounted } from 'vue'
 import { Map, View } from 'ol'
 import DataCabinet from './DataCabinet.vue'
 import Snackbar from './Snackbar.vue'
@@ -10,19 +10,13 @@ import { generateJWT } from '../functions/generate-jwt'
 import { useAreaOfInterest } from '../composables/useAreaOfInterest'
 import { useSearch } from '../composables/useSearch'
 import { usePermalink } from '../composables/usePermalink'
+import { useMap } from '../composables/useMap'
 
-const map = shallowRef<Map | null>(null)
+const { map, areaValues } = useMap()
 const dataCabinetRef = ref<InstanceType<typeof DataCabinet> | null>(null)
-const areaValues = ref<{ min_area_km2: number; max_area_km2: number } | null>(null)
 const geoJSONResults = ref<any[]>([])
 
-const {
-  addMapClickHandler,
-  currentMgrsTileId,
-  activeTileId,
-  secondActiveTileId,
-  triggerTileSelection,
-} = useAreaOfInterest()
+const { addMapClickHandler } = useAreaOfInterest()
 const { searchResults, handleSearchResults } = useSearch()
 const { setupPermalink } = usePermalink()
 
@@ -73,33 +67,11 @@ onMounted(async () => {
   // Add S2 Grid layer after map is initialized
   if (map.value) {
     const s2GridLayer = createS2GridLayer()
-    addMapClickHandler(
-      map.value as Map,
-      dataCabinetRef,
-      areaValues.value,
-      searchResults,
-      handleSearchResults,
-    )
+    addMapClickHandler(map.value as Map, areaValues.value, searchResults, handleSearchResults)
     map.value.addLayer(s2GridLayer)
 
     // Setup permalink functionality
-    setupPermalink(
-      map.value,
-      currentMgrsTileId,
-      activeTileId,
-      secondActiveTileId,
-      (mgrsTileId: string) => {
-        // This callback will be called when a permalink is loaded with a tile ID
-        // It will automatically trigger the search and tile selection
-        triggerTileSelection(
-          map.value!,
-          mgrsTileId,
-          dataCabinetRef,
-          areaValues.value!,
-          handleSearchResults,
-        )
-      },
-    )
+    setupPermalink()
   }
 })
 

--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, onUnmounted, watch, shallowRef } from 'vue'
-import type Map from 'ol/Map'
 import type { Extent } from 'ol/extent'
 import { generateJWT } from '../functions/generate-jwt'
 import { transformExtent } from 'ol/proj'
@@ -16,12 +15,11 @@ import { useStacLayer } from '../composables/useStacLayer'
 import { useAreaOfInterest } from '../composables/useAreaOfInterest'
 import PropertyDisplay from './PropertyDisplay.vue'
 import { formatMeasurementDisplay } from '../functions/format-measurement-display'
-import { usePermalink } from '../composables/usePermalink'
+import { useProcessingMode } from '../composables/useProcessingMode'
+import { useMap } from '../composables/useMap'
 
 const props = defineProps<{
-  map: Map
   isOpen: boolean
-  processingMode: 'smallAreaProcessing' | 'batchProcessing' | null
 }>()
 
 const emit = defineEmits<{
@@ -29,10 +27,10 @@ const emit = defineEmits<{
   (e: 'updateGeoJSONResults', results: any[]): void
 }>()
 
+const { map } = useMap()
 const { addStacLayer, removeStacLayer } = useStacLayer()
 const { removeExtentInteraction, removeDrawVectorLayer, drawnExtent } = useAreaOfInterest()
 const { projectMessage, dismissMessage } = useProjectMessage()
-const { updateTileSelection } = usePermalink()
 
 const {
   currentBbox,
@@ -61,13 +59,7 @@ watch(activeTileId, (newValue) => {
 })
 
 const isOpen = ref(props.isOpen)
-const processingMode = ref(props.processingMode)
-watch(
-  () => props.processingMode,
-  (newValue) => {
-    processingMode.value = newValue
-  },
-)
+const { processingMode } = useProcessingMode()
 
 const isCreatingProject = ref(false)
 const isProcessing = ref(false)
@@ -127,7 +119,7 @@ const handleMapClick = (event: any) => {
   let clickedFeature: any = null
 
   // Check if we clicked on a feature from our results layer
-  props.map.forEachFeatureAtPixel(pixel, (feature) => {
+  map.value?.forEachFeatureAtPixel(pixel, (feature) => {
     // Only process features from our results layer
     if (
       vectorLayer.value
@@ -274,12 +266,12 @@ const handleViewOnMap = (
     }
 
     if (secondActiveTileId.value === tileId) {
-      removeStacLayer(props.map)
+      removeStacLayer(map.value!)
       secondActiveTileId.value = null
     } else {
-      removeStacLayer(props.map)
+      removeStacLayer(map.value!)
       if (gridExtent) {
-        addStacLayer(props.map, imageUrl, gridExtent)
+        addStacLayer(map.value!, imageUrl, gridExtent)
         secondActiveTileId.value = tileId
       } else {
         console.error('No bounds available for this image')
@@ -287,15 +279,15 @@ const handleViewOnMap = (
     }
   } else {
     if (activeTileId.value === tileId) {
-      removeStacLayer(props.map)
+      removeStacLayer(map.value!)
       activeTileId.value = null
       if (secondActiveTileId.value === tileId) {
         secondActiveTileId.value = null
       }
     } else {
-      removeStacLayer(props.map)
+      removeStacLayer(map.value!)
       if (gridExtent) {
-        addStacLayer(props.map, imageUrl, gridExtent)
+        addStacLayer(map.value!, imageUrl, gridExtent)
         activeTileId.value = tileId
         if (secondActiveTileId.value === tileId) {
           secondActiveTileId.value = null
@@ -305,14 +297,6 @@ const handleViewOnMap = (
       }
     }
   }
-
-  // Update permalink after tile selection changes
-  updateTileSelection(
-    props.map,
-    currentMgrsTileId.value,
-    activeTileId.value,
-    secondActiveTileId.value,
-  )
 }
 
 const getActiveTileThumbnail = (isSecond: boolean = false) => {
@@ -369,7 +353,7 @@ const fitMapToBbox = (bbox: number[]) => {
   }
 
   // TODO: FIX ISSUE WITH SCROLLING AND CHANGE LAYER COLOR
-  props.map.getView().fit(extent, {
+  map.value?.getView().fit(extent, {
     padding: [50, 50, 50, 50],
     duration: 500,
   })
@@ -378,7 +362,7 @@ const fitMapToBbox = (bbox: number[]) => {
 const displayGeoJSON = (geojson: FeatureCollection & { crs: { properties: { name: string } } }) => {
   // Remove existing vector layer if it exists
   if (vectorLayer.value) {
-    props.map.removeLayer(vectorLayer.value)
+    map.value?.removeLayer(vectorLayer.value)
   }
 
   // Create new vector source and layer
@@ -408,7 +392,7 @@ const displayGeoJSON = (geojson: FeatureCollection & { crs: { properties: { name
   })
 
   // Ensure the results layer is on top by setting a high z-index
-  props.map.addLayer(vectorLayer.value)
+  map.value?.addLayer(vectorLayer.value)
 
   // Emit the GeoJSON results to the parent component
   const results = source.getFeatures().map((feature) => ({
@@ -419,7 +403,7 @@ const displayGeoJSON = (geojson: FeatureCollection & { crs: { properties: { name
   emit('updateGeoJSONResults', results)
 
   // Add map click handler to detect feature clicks and show properties
-  props.map.on('click', handleMapClick)
+  map.value?.on('click', handleMapClick)
 
   // Get the extent and validate it
   const extent = source.getExtent()
@@ -502,7 +486,7 @@ const handleSmallAreaProcessingRequest = async () => {
         fitMapToBbox(extent)
         projectMessage.value = { type: 'success', text: 'Small area processed successfully' }
         // Remove the editable bbox since we have results
-        removeDrawVectorLayer(props.map)
+        removeDrawVectorLayer(map.value!)
       } else {
         // displayGeoJSON returned null, which means no valid features or invalid extent
         projectMessage.value = {
@@ -529,8 +513,8 @@ const handleSmallAreaProcessingRequest = async () => {
       }, 5000)
     }
 
-    removeStacLayer(props.map)
-    removeStacLayer(props.map, true)
+    removeStacLayer(map.value!)
+    removeStacLayer(map.value!, true)
     removeExtentInteraction()
   } catch (error) {
     console.error('Error processing small area:', error)
@@ -736,8 +720,8 @@ const handleCompareTiles = async () => {
               fitMapToBbox(extent)
             }
           }
-          removeStacLayer(props.map)
-          removeStacLayer(props.map, true)
+          removeStacLayer(map.value!)
+          removeStacLayer(map.value!, true)
           removeExtentInteraction()
 
           projectMessage.value = {
@@ -745,7 +729,7 @@ const handleCompareTiles = async () => {
             text: 'Batch processing completed',
           }
           // Remove the editable bbox since batch processing completed successfully
-          removeDrawVectorLayer(props.map)
+          removeDrawVectorLayer(map.value!)
           // Clear message after 3 seconds
           setTimeout(() => {
             projectMessage.value = null
@@ -793,8 +777,8 @@ const handleCompareTiles = async () => {
 
 // Clean up map click handler when component is unmounted
 onUnmounted(() => {
-  if (props.map) {
-    props.map.un('click', handleMapClick)
+  if (map.value) {
+    map.value.un('click', handleMapClick)
   }
 })
 

--- a/src/components/SearchModal.vue
+++ b/src/components/SearchModal.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-import type { Map } from 'ol'
 import { mdiMagnify, mdiClose } from '@mdi/js'
 import { useAreaOfInterest } from '../composables/useAreaOfInterest'
 import { fromExtent } from 'ol/geom/Polygon'
+import { useMap } from '../composables/useMap'
 
 interface Props {
   isOpen: boolean
-  map: Map
-  areaValues: { min_area_km2: number; max_area_km2: number }
 }
 
 interface Emits {
@@ -24,6 +22,7 @@ interface Emits {
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
+const { map, areaValues } = useMap()
 // Use the area calculation function and drawnExtent from the composable
 const { calculateArea } = useAreaOfInterest()
 
@@ -94,19 +93,22 @@ const parseBboxInput = (input: string): { isValid: boolean; bbox: number[]; erro
 
 // Function to validate bbox area
 const validateBboxArea = (bbox: number[]): { isValid: boolean; message: string } => {
+  if (!areaValues.value) {
+    return { isValid: false, message: 'Area values are not available' }
+  }
   const area = calculateBboxArea(bbox)
 
-  if (area < props.areaValues.min_area_km2) {
+  if (area < areaValues.value.min_area_km2) {
     return {
       isValid: false,
-      message: `Bounding box area (${area.toFixed(2)} km²) is too small. Minimum area required: ${props.areaValues.min_area_km2} km²`,
+      message: `Bounding box area (${area.toFixed(2)} km²) is too small. Minimum area required: ${areaValues.value.min_area_km2} km²`,
     }
   }
 
-  if (area > props.areaValues.max_area_km2) {
+  if (area > areaValues.value.max_area_km2) {
     return {
       isValid: false,
-      message: `Bounding box area (${area.toFixed(2)} km²) is too large. Maximum area allowed: ${props.areaValues.max_area_km2} km²`,
+      message: `Bounding box area (${area.toFixed(2)} km²) is too large. Maximum area allowed: ${areaValues.value.max_area_km2} km²`,
     }
   }
 
@@ -127,11 +129,11 @@ const closeModal = () => {
 
 // Load available S2 tiles from the map layer
 const loadAvailableTiles = () => {
-  if (!props.map) {
+  if (!map.value) {
     return
   }
 
-  const layers = props.map.getLayers().getArray()
+  const layers = map.value.getLayers().getArray()
 
   const s2GridLayer = layers.find(
     (layer) =>
@@ -185,7 +187,7 @@ const navigateToTileAndSearch = () => {
     const extent = geometry.getExtent()
 
     // Fit the map view to the tile extent with padding
-    props.map.getView().fit(extent, {
+    map.value?.getView().fit(extent, {
       duration: 1000,
       maxZoom: 13,
       padding: [50, 50, 50, 50],
@@ -298,7 +300,7 @@ onMounted(() => {
 
 // Watch for map changes to reload tiles
 watch(
-  () => props.map,
+  () => map.value,
   (newMap) => {
     if (newMap) {
       loadAvailableTiles()
@@ -318,7 +320,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div v-if="isOpen" class="modal-overlay" @click="closeModal">
+  <div v-if="props.isOpen" class="modal-overlay" @click="closeModal">
     <div class="modal-content" @click.stop>
       <div class="modal-header">
         <h3>Select S2 Grid and Search Parameters</h3>

--- a/src/composables/useAreaOfInterest.ts
+++ b/src/composables/useAreaOfInterest.ts
@@ -11,7 +11,7 @@ import {
 } from 'ol/extent'
 import ExtentInteraction from 'ol/interaction/Extent'
 import { Fill, Stroke, Style } from 'ol/style'
-import { ref, type Ref, shallowRef } from 'vue'
+import { nextTick, ref, type Ref, shallowRef, watch } from 'vue'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import Polygon, { fromExtent } from 'ol/geom/Polygon'
@@ -21,6 +21,7 @@ import { showWarning } from '../functions/snackbar'
 import { booleanWithin as turfBooleanWithin } from '@turf/boolean-within'
 import { clearSearchResults, searchResults, type SearchResults } from './useSearch'
 import { Feature as GeoJSONFeature, Polygon as GeoJSONPolygon } from 'geojson'
+import { areaValues, map } from './useMap'
 
 const invalidStyle = new Style({
   stroke: new Stroke({
@@ -47,16 +48,40 @@ export const currentMgrsTileId = ref<string | null>(null)
 export const activeTileId = ref<string | null>(null)
 export const secondActiveTileId = ref<string | null>(null)
 /** Full grid extent */
-const currentGridExtent = ref<Extent | null>(null)
+const currentGridExtent = shallowRef<Extent | null>(null)
 /** User bbox */
-const drawnExtent = ref<Extent | null>(null)
+export const drawnExtent = shallowRef<Extent | null>(null)
 /** Flag to block map clicks when results are displayed */
 const blockMapClicks = ref(false)
 
 const extentFeature: Feature<Polygon> = new Feature()
+
+let updatingDrawnExtent = false
+watch(
+  drawnExtent,
+  (newValue) => {
+    if (updatingDrawnExtent) {
+      return
+    }
+    updatingDrawnExtent = true
+    extentFeature.setGeometry(newValue ? fromExtent(newValue) : undefined)
+    if (newValue) {
+      extentInteraction.value?.setExtent(newValue)
+    }
+    updatingDrawnExtent = false
+  },
+  { immediate: true },
+)
 extentFeature.on('change', () => {
+  if (updatingDrawnExtent) {
+    return
+  }
   const bbox = extentFeature?.getGeometry()?.getExtent() || null
+  updatingDrawnExtent = true
   drawnExtent.value = bbox // Update the drawn extent in the composable
+  nextTick(() => {
+    updatingDrawnExtent = false
+  })
 })
 
 const drawVectorLayer: VectorLayer<VectorSource> = new VectorLayer({
@@ -66,14 +91,9 @@ const drawVectorLayer: VectorLayer<VectorSource> = new VectorLayer({
   zIndex: 1001,
 })
 
-function addExtentInteraction(
-  map: Map,
-  bboxExtent: Extent,
-  areaValues: { min_area_km2: number; max_area_km2: number },
-  searchResults: SearchResults,
-) {
+function addExtentInteraction(searchResults: SearchResults) {
   extentInteraction.value = new ExtentInteraction({
-    extent: bboxExtent,
+    extent: drawnExtent.value || undefined,
     createCondition: never,
     drag: true,
     boxStyle: new Style({
@@ -82,7 +102,7 @@ function addExtentInteraction(
       }),
     }),
   })
-  map.addInteraction(extentInteraction.value)
+  map.value!.addInteraction(extentInteraction.value)
 
   let warningShown = false
 
@@ -96,17 +116,21 @@ function addExtentInteraction(
       : false
     // Check if the polygon is within the grid extent and within size limits
 
-    if (area > areaValues?.max_area_km2 || area < areaValues?.min_area_km2 || !isWithinExtent) {
+    if (
+      area > areaValues.value!.max_area_km2 ||
+      area < areaValues.value!.min_area_km2 ||
+      !isWithinExtent
+    ) {
       if (!warningShown) {
         // Show notification for each validation error
-        if (area > areaValues?.max_area_km2) {
+        if (area > areaValues.value!.max_area_km2) {
           showWarning(
-            `Bounding box area exceeds ${areaValues?.max_area_km2} square kilometers. Using last valid state.`,
+            `Bounding box area exceeds ${areaValues.value?.max_area_km2} square kilometers. Using last valid state.`,
           )
         }
-        if (area < areaValues?.min_area_km2) {
+        if (area < areaValues.value!.min_area_km2) {
           showWarning(
-            `Bounding box area is less than ${areaValues?.min_area_km2} square kilometers. Using last valid state.`,
+            `Bounding box area is less than ${areaValues.value?.min_area_km2} square kilometers. Using last valid state.`,
           )
         }
         if (!isWithinExtent) {
@@ -299,7 +323,7 @@ function addMapClickHandler(
   map: Map,
   areaValues: { min_area_km2: number; max_area_km2: number },
   searchResults: SearchResults,
-  handleSearchResults: (mgrsTileId: string, bbox?: number[], settings?: any) => void,
+  handleSearchResults: (mgrsTileId: string, bbox?: number[], settings?: any) => Promise<void>,
 ) {
   // Add click handler
   map?.on('click', (event) => {
@@ -410,7 +434,7 @@ function addMapClickHandler(
         }
 
         // Create and add Modify interaction with size restriction
-        addExtentInteraction(map, bboxExtent, areaValues, searchResults)
+        addExtentInteraction(searchResults)
         extentFound = true
         break
       }
@@ -427,12 +451,13 @@ function addMapClickHandler(
 }
 
 // Function to programmatically trigger tile selection and search
-export function triggerTileSelection(
+export async function triggerTileSelection(
   map: Map,
   mgrsTileId: string,
   areaValues: { min_area_km2: number; max_area_km2: number },
-  handleSearchResults: (mgrsTileId: string, bbox?: number[], settings?: any) => void,
+  handleSearchResults: (mgrsTileId: string, bbox?: number[], settings?: any) => Promise<void>,
   bbox?: number[],
+  fit: boolean = true,
 ) {
   // Set the current MGRS tile ID
   currentMgrsTileId.value = mgrsTileId
@@ -481,10 +506,12 @@ export function triggerTileSelection(
       const paddedExtent = buffer(extent, padding)
 
       // Fit the view to the extent
-      map.getView().fit(paddedExtent, {
-        duration: 1000,
-        maxZoom: 13,
-      })
+      if (fit) {
+        map.getView().fit(paddedExtent, {
+          duration: 1000,
+          maxZoom: 13,
+        })
+      }
 
       // Use provided bbox or create a smaller bbox within the grid to avoid overlap with adjacent grids
       let finalBbox: number[]
@@ -531,13 +558,13 @@ export function triggerTileSelection(
           }
         }
 
-        handleSearchResults(currentMgrsTileId.value, finalBbox, currentSettings)
+        await handleSearchResults(currentMgrsTileId.value, finalBbox, currentSettings)
       }
       // Add the layer and interactions
       if (!layers.includes(drawVectorLayer)) {
         map.addLayer(drawVectorLayer)
       }
-      addExtentInteraction(map, bboxExtent, areaValues, searchResults)
+      addExtentInteraction(searchResults)
     }
   }
 }

--- a/src/composables/useAreaOfInterest.ts
+++ b/src/composables/useAreaOfInterest.ts
@@ -6,12 +6,12 @@ import {
   getHeight,
   getIntersection,
   getWidth,
+  isEmpty,
   type Extent,
 } from 'ol/extent'
 import ExtentInteraction from 'ol/interaction/Extent'
 import { Fill, Stroke, Style } from 'ol/style'
 import { ref, type Ref, shallowRef } from 'vue'
-import type DataCabinet from '../components/DataCabinet.vue'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import Polygon, { fromExtent } from 'ol/geom/Polygon'
@@ -19,12 +19,8 @@ import { transformExtent } from 'ol/proj'
 import { getArea } from 'ol/sphere'
 import { showWarning } from '../functions/snackbar'
 import { booleanWithin as turfBooleanWithin } from '@turf/boolean-within'
-import { useSearch, type SearchResults } from './useSearch'
+import { clearSearchResults, searchResults, type SearchResults } from './useSearch'
 import { Feature as GeoJSONFeature, Polygon as GeoJSONPolygon } from 'geojson'
-import { usePermalink } from './usePermalink'
-
-const { clearSearchResults, searchResults } = useSearch()
-const { updateTileSelection } = usePermalink()
 
 const invalidStyle = new Style({
   stroke: new Stroke({
@@ -47,9 +43,9 @@ const validStyle = new Style({
 })
 
 const extentInteraction = shallowRef<ExtentInteraction | null>(null)
-const currentMgrsTileId = ref<string | null>(null)
-const activeTileId = ref<string | null>(null)
-const secondActiveTileId = ref<string | null>(null)
+export const currentMgrsTileId = ref<string | null>(null)
+export const activeTileId = ref<string | null>(null)
+export const secondActiveTileId = ref<string | null>(null)
 /** Full grid extent */
 const currentGridExtent = ref<Extent | null>(null)
 /** User bbox */
@@ -301,7 +297,6 @@ const checkBboxContainment = (
 
 function addMapClickHandler(
   map: Map,
-  dataCabinetRef: Ref<InstanceType<typeof DataCabinet> | null>,
   areaValues: { min_area_km2: number; max_area_km2: number },
   searchResults: SearchResults,
   handleSearchResults: (mgrsTileId: string, bbox?: number[], settings?: any) => void,
@@ -315,9 +310,10 @@ function addMapClickHandler(
 
     removeExtentInteraction()
 
-    const feature = map.forEachFeatureAtPixel(event.pixel, (feature) => feature)
+    const features = map.getFeaturesAtPixel(event.pixel)
 
-    if (feature) {
+    let extentFound = false
+    for (const feature of features) {
       // Get the MGRS Tile ID from the feature properties
       const mgrsTileId = feature.get('Name')
       currentMgrsTileId.value = mgrsTileId
@@ -343,6 +339,9 @@ function addMapClickHandler(
           extent,
           calculateBoundingBox(extentAtClickedPosition, areaValues),
         )
+        if (isEmpty(bboxExtent)) {
+          continue
+        }
 
         // Set initial bounding box
         const bboxPolygon = fromExtent(bboxExtent)
@@ -401,10 +400,6 @@ function addMapClickHandler(
           }
 
           handleSearchResults(currentMgrsTileId.value, bbox, currentSettings)
-          // Open the Batch Processing accordion
-          if (dataCabinetRef.value?.handleProcessingToggle) {
-            dataCabinetRef.value.handleProcessingToggle(true)
-          }
         } else {
           console.error('S2 Grid Layer: Current MGRS Tile ID is null')
         }
@@ -416,8 +411,11 @@ function addMapClickHandler(
 
         // Create and add Modify interaction with size restriction
         addExtentInteraction(map, bboxExtent, areaValues, searchResults)
+        extentFound = true
+        break
       }
-    } else {
+    }
+    if (!extentFound) {
       // If clicked outside a feature, clear the selection
       if (drawVectorLayer) {
         map.removeLayer(drawVectorLayer)
@@ -429,10 +427,9 @@ function addMapClickHandler(
 }
 
 // Function to programmatically trigger tile selection and search
-function triggerTileSelection(
+export function triggerTileSelection(
   map: Map,
   mgrsTileId: string,
-  dataCabinetRef: Ref<InstanceType<typeof DataCabinet> | null>,
   areaValues: { min_area_km2: number; max_area_km2: number },
   handleSearchResults: (mgrsTileId: string, bbox?: number[], settings?: any) => void,
   bbox?: number[],
@@ -535,13 +532,7 @@ function triggerTileSelection(
         }
 
         handleSearchResults(currentMgrsTileId.value, finalBbox, currentSettings)
-
-        // Open the Batch Processing accordion
-        if (dataCabinetRef.value?.handleProcessingToggle) {
-          dataCabinetRef.value.handleProcessingToggle(true)
-        }
       }
-      console.log(map.getLayers().getArray())
       // Add the layer and interactions
       if (!layers.includes(drawVectorLayer)) {
         map.addLayer(drawVectorLayer)
@@ -567,13 +558,5 @@ export function useAreaOfInterest() {
     clearResultsAndZoomToGrid,
     triggerTileSelection,
     calculateArea,
-    updatePermalink: (map: Map) => {
-      updateTileSelection(
-        map,
-        currentMgrsTileId.value,
-        activeTileId.value,
-        secondActiveTileId.value,
-      )
-    },
   }
 }

--- a/src/composables/useMap.ts
+++ b/src/composables/useMap.ts
@@ -1,0 +1,12 @@
+import type Map from 'ol/Map'
+import { ref, shallowRef } from 'vue'
+
+export const map = shallowRef<Map | null>(null)
+export const areaValues = ref<{ min_area_km2: number; max_area_km2: number } | null>(null)
+
+export function useMap() {
+  return {
+    map,
+    areaValues,
+  }
+}

--- a/src/composables/usePermalink.ts
+++ b/src/composables/usePermalink.ts
@@ -8,6 +8,7 @@ import {
 } from './useAreaOfInterest'
 import { map, areaValues } from './useMap'
 import { handleSearchResults } from './useSearch'
+import { fromLonLat, toLonLat } from 'ol/proj'
 
 export interface PermalinkState {
   zoom: number
@@ -47,7 +48,7 @@ const parsePermalink = (): PermalinkState => {
     if (parts.length >= 3) {
       const result: PermalinkState = {
         zoom: parseFloat(parts[0]) || defaultState.zoom,
-        center: [parseFloat(parts[1]), parseFloat(parts[2])] as [number, number],
+        center: [parseFloat(parts[2]), parseFloat(parts[1])] as [number, number],
         currentMgrsTileId: null,
         activeTileId: null,
         secondActiveTileId: null,
@@ -100,13 +101,14 @@ const updatePermalink = (
   }
 
   const view = map.getView()
-  const center = view.getCenter()
+  const viewCenter = view.getCenter()
   const zoom = view.getZoom()
+  if (!viewCenter || zoom === undefined) return
 
-  if (!center || zoom === undefined) return
+  const center = toLonLat(viewCenter)
 
   // Build hash parts, excluding null values
-  const hashParts = [zoom.toFixed(2), center[0].toFixed(2), center[1].toFixed(2)]
+  const hashParts = [zoom.toFixed(2), center[1].toFixed(5), center[0].toFixed(5)]
 
   // Only add non-null tile IDs to the hash
   if (currentMgrsTileId) {
@@ -137,7 +139,7 @@ const updatePermalink = (
 
   const state: PermalinkState = {
     zoom,
-    center: [center[0], center[1]],
+    center: [center[1], center[0]],
     currentMgrsTileId,
     activeTileId,
     secondActiveTileId,
@@ -150,7 +152,7 @@ const restoreMapState = (map: Map, state: PermalinkState) => {
   const view = map.getView()
 
   // Set center and zoom
-  view.setCenter(state.center)
+  view.setCenter(fromLonLat(state.center))
   view.setZoom(state.zoom)
 
   // Note: Tile IDs will be restored by the calling component

--- a/src/composables/usePermalink.ts
+++ b/src/composables/usePermalink.ts
@@ -1,5 +1,13 @@
-import { ref, type Ref } from 'vue'
-import type { Map } from 'ol'
+import { watch } from 'vue'
+import type Map from 'ol/Map'
+import {
+  activeTileId,
+  currentMgrsTileId,
+  secondActiveTileId,
+  triggerTileSelection,
+} from './useAreaOfInterest'
+import { map, areaValues } from './useMap'
+import { handleSearchResults } from './useSearch'
 
 export interface PermalinkState {
   zoom: number
@@ -14,224 +22,237 @@ export interface PermalinkState {
   areaCoverage?: number
 }
 
-export function usePermalink() {
-  const shouldUpdate = ref(true)
+let registered = false
+let shouldUpdate = true
 
-  // Default values
-  const defaultState: PermalinkState = {
-    zoom: 2,
-    center: [0, 0],
-    currentMgrsTileId: null,
-    activeTileId: null,
-    secondActiveTileId: null,
-  }
+// Default values
+const defaultState: PermalinkState = {
+  zoom: 2,
+  center: [0, 0],
+  currentMgrsTileId: null,
+  activeTileId: null,
+  secondActiveTileId: null,
+}
 
-  // Parse permalink from URL hash
-  const parsePermalink = (): PermalinkState => {
-    if (window.location.hash === '') {
-      return defaultState
-    }
-
-    try {
-      const hash = window.location.hash.replace('#map=', '')
-      const parts = hash.split('/')
-
-      if (parts.length >= 3) {
-        const result: PermalinkState = {
-          zoom: parseFloat(parts[0]) || defaultState.zoom,
-          center: [parseFloat(parts[1]), parseFloat(parts[2])] as [number, number],
-          currentMgrsTileId: null,
-          activeTileId: null,
-          secondActiveTileId: null,
-        }
-
-        // Parse additional parts as tile IDs (only if they exist and are not null)
-        if (parts.length >= 4 && parts[3] !== 'null') {
-          result.currentMgrsTileId = parts[3]
-        }
-        if (parts.length >= 5 && parts[4] !== 'null') {
-          result.activeTileId = parts[4]
-        }
-        if (parts.length >= 6 && parts[5] !== 'null') {
-          result.secondActiveTileId = parts[5]
-        }
-
-        // Parse search settings
-        for (let i = 6; i < parts.length; i++) {
-          const part = parts[i]
-          if (part.startsWith('start_date:')) {
-            result.startDate = part.substring(2)
-          } else if (part.startsWith('end_date:')) {
-            result.endDate = part.substring(2)
-          } else if (part.startsWith('cloud_cover:')) {
-            result.cloudCover = parseInt(part.substring(2))
-          } else if (part.startsWith('area_coverage:')) {
-            result.areaCoverage = parseInt(part.substring(2))
-          }
-        }
-
-        return result
-      }
-    } catch (error) {
-      console.error('Error parsing permalink:', error)
-    }
-
+// Parse permalink from URL hash
+const parsePermalink = (): PermalinkState => {
+  if (window.location.hash === '') {
     return defaultState
   }
 
-  // Update permalink in URL
-  const updatePermalink = (
-    map: Map,
-    currentMgrsTileId: string | null,
-    activeTileId: string | null,
-    secondActiveTileId: string | null,
-  ) => {
-    if (!shouldUpdate.value) {
-      shouldUpdate.value = true
+  try {
+    const hash = window.location.hash.replace('#map=', '')
+    const parts = hash.split('/')
+
+    if (parts.length >= 3) {
+      const result: PermalinkState = {
+        zoom: parseFloat(parts[0]) || defaultState.zoom,
+        center: [parseFloat(parts[1]), parseFloat(parts[2])] as [number, number],
+        currentMgrsTileId: null,
+        activeTileId: null,
+        secondActiveTileId: null,
+      }
+
+      // Parse additional parts as tile IDs (only if they exist and are not null)
+      if (parts.length >= 4 && parts[3] !== 'null') {
+        result.currentMgrsTileId = parts[3]
+      }
+      if (parts.length >= 5 && parts[4] !== 'null') {
+        result.activeTileId = parts[4]
+      }
+      if (parts.length >= 6 && parts[5] !== 'null') {
+        result.secondActiveTileId = parts[5]
+      }
+
+      // Parse search settings
+      for (let i = 6; i < parts.length; i++) {
+        const part = parts[i]
+        if (part.startsWith('start_date:')) {
+          result.startDate = part.substring(11)
+        } else if (part.startsWith('end_date:')) {
+          result.endDate = part.substring(9)
+        } else if (part.startsWith('cloud_cover:')) {
+          result.cloudCover = Number(part.substring(12))
+        } else if (part.startsWith('area_coverage:')) {
+          result.areaCoverage = Number(part.substring(14))
+        }
+      }
+
+      return result
+    }
+  } catch (error) {
+    console.error('Error parsing permalink:', error)
+  }
+
+  return defaultState
+}
+
+// Update permalink in URL
+const updatePermalink = (
+  map: Map,
+  currentMgrsTileId: string | null,
+  activeTileId: string | null,
+  secondActiveTileId: string | null,
+) => {
+  if (!shouldUpdate) {
+    shouldUpdate = true
+    return
+  }
+
+  const view = map.getView()
+  const center = view.getCenter()
+  const zoom = view.getZoom()
+
+  if (!center || zoom === undefined) return
+
+  // Build hash parts, excluding null values
+  const hashParts = [zoom.toFixed(2), center[0].toFixed(2), center[1].toFixed(2)]
+
+  // Only add non-null tile IDs to the hash
+  if (currentMgrsTileId) {
+    hashParts.push(currentMgrsTileId)
+    hashParts.push(String(activeTileId))
+    hashParts.push(String(secondActiveTileId))
+  }
+
+  // If we have a currentMgrsTileId, include search settings
+  if (currentMgrsTileId) {
+    const stored = localStorage.getItem('ftw-search-settings')
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        // Add search settings to the hash
+        if (parsed.startDate) hashParts.push(`start_date:${parsed.startDate}`)
+        if (parsed.endDate) hashParts.push(`end_date:${parsed.endDate}`)
+        if (parsed.cloudCover !== undefined) hashParts.push(`cloud_cover:${parsed.cloudCover}`)
+        if (parsed.areaCoverage !== undefined)
+          hashParts.push(`area_coverage:${parsed.areaCoverage}`)
+      } catch (error) {
+        console.error('Error parsing stored settings for permalink:', error)
+      }
+    }
+  }
+
+  const hash = `#map=${hashParts.join('/')}`
+
+  const state: PermalinkState = {
+    zoom,
+    center: [center[0], center[1]],
+    currentMgrsTileId,
+    activeTileId,
+    secondActiveTileId,
+  }
+  window.history.pushState(state, 'map', hash)
+}
+
+// Restore map state from permalink
+const restoreMapState = (map: Map, state: PermalinkState) => {
+  const view = map.getView()
+
+  // Set center and zoom
+  view.setCenter(state.center)
+  view.setZoom(state.zoom)
+
+  // Note: Tile IDs will be restored by the calling component
+  // since they need to be set in the composable state
+}
+
+// Setup permalink functionality
+const setupPermalink = () => {
+  if (!map.value) {
+    throw new Error('Map is not initialized yet')
+  }
+  if (registered) {
+    return
+  }
+  registered = true
+
+  watch(
+    () => [map.value, currentMgrsTileId.value, activeTileId.value, secondActiveTileId.value],
+    () => {
+      if (!map.value) {
+        return
+      }
+      // Update permalink after tile selection changes
+      updateTileSelection(
+        map.value,
+        currentMgrsTileId.value,
+        activeTileId.value,
+        secondActiveTileId.value,
+      )
+    },
+  )
+
+  // Restore initial state from URL
+  const initialState = parsePermalink()
+  restoreMapState(map.value, initialState)
+
+  // Update the refs with the restored values
+  currentMgrsTileId.value = initialState.currentMgrsTileId
+  activeTileId.value = initialState.activeTileId
+  secondActiveTileId.value = initialState.secondActiveTileId
+
+  // If we have a restored MGRS tile ID, trigger the search
+  if (initialState.currentMgrsTileId) {
+    // Use setTimeout to ensure the map is fully initialized
+    setTimeout(() => {
+      triggerTileSelection(
+        map.value!,
+        currentMgrsTileId.value!,
+        areaValues.value!,
+        handleSearchResults,
+      )
+    }, 100)
+  }
+
+  // Update permalink when map moves
+  map.value.on('moveend', () => {
+    updatePermalink(
+      map.value!,
+      currentMgrsTileId.value,
+      activeTileId.value,
+      secondActiveTileId.value,
+    )
+  })
+
+  // Handle browser back/forward navigation
+  window.addEventListener('popstate', (event) => {
+    if (event.state === null) {
       return
     }
 
-    const view = map.getView()
-    const center = view.getCenter()
-    const zoom = view.getZoom()
+    const state = event.state as PermalinkState
+    restoreMapState(map.value!, state)
 
-    if (!center || zoom === undefined) return
-
-    // Build hash parts, excluding null values
-    const hashParts = [zoom.toFixed(2), center[0].toFixed(2), center[1].toFixed(2)]
-
-    // Only add non-null tile IDs to the hash
-    if (currentMgrsTileId) hashParts.push(currentMgrsTileId)
-    if (activeTileId) hashParts.push(activeTileId)
-    if (secondActiveTileId) hashParts.push(secondActiveTileId)
-
-    // If we have a currentMgrsTileId, include search settings
-    if (currentMgrsTileId) {
-      const stored = localStorage.getItem('ftw-search-settings')
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored)
-          // Add search settings to the hash
-          if (parsed.startDate) hashParts.push(`start_date:${parsed.startDate}`)
-          if (parsed.endDate) hashParts.push(`end_date:${parsed.endDate}`)
-          if (parsed.cloudCover !== undefined) hashParts.push(`cloud_cover:${parsed.cloudCover}`)
-          if (parsed.areaCoverage !== undefined)
-            hashParts.push(`area_coverage:${parsed.areaCoverage}`)
-        } catch (error) {
-          console.error('Error parsing stored settings for permalink:', error)
-        }
-      }
-    }
-
-    const hash = `#map=${hashParts.join('/')}`
-
-    const state: PermalinkState = {
-      zoom,
-      center: [center[0], center[1]],
-      currentMgrsTileId,
-      activeTileId,
-      secondActiveTileId,
-    }
-
-    window.history.pushState(state, 'map', hash)
-  }
-
-  // Restore map state from permalink
-  const restoreMapState = (map: Map, state: PermalinkState) => {
-    const view = map.getView()
-
-    // Set center and zoom
-    view.setCenter(state.center)
-    view.setZoom(state.zoom)
-
-    // Note: Tile IDs will be restored by the calling component
-    // since they need to be set in the composable state
-  }
-
-  // Setup permalink functionality
-  const setupPermalink = (
-    map: Map,
-    currentMgrsTileId: Ref<string | null>,
-    activeTileId: Ref<string | null>,
-    secondActiveTileId: Ref<string | null>,
-    onTileRestore?: (mgrsTileId: string, searchSettings?: any) => void,
-  ) => {
-    // Restore initial state from URL
-    const initialState = parsePermalink()
-    restoreMapState(map, initialState)
-
-    // Update the refs with the restored values
-    currentMgrsTileId.value = initialState.currentMgrsTileId
-    activeTileId.value = initialState.activeTileId
-    secondActiveTileId.value = initialState.secondActiveTileId
+    // Update the refs
+    currentMgrsTileId.value = state.currentMgrsTileId
+    activeTileId.value = state.activeTileId
+    secondActiveTileId.value = state.secondActiveTileId
 
     // If we have a restored MGRS tile ID, trigger the search
-    if (initialState.currentMgrsTileId && onTileRestore) {
-      // Prepare search settings from permalink
-      const searchSettings = {
-        startDate: initialState.startDate || '',
-        endDate: initialState.endDate || '',
-        cloudCover: initialState.cloudCover || 10,
-        areaCoverage: initialState.areaCoverage || 60,
-      }
-
-      // Use setTimeout to ensure the map is fully initialized
-      setTimeout(() => {
-        onTileRestore(initialState.currentMgrsTileId!, searchSettings)
-      }, 100)
+    if (state.currentMgrsTileId) {
+      triggerTileSelection(
+        map.value!,
+        currentMgrsTileId.value!,
+        areaValues.value!,
+        handleSearchResults,
+      )
     }
 
-    // Update permalink when map moves
-    map.on('moveend', () => {
-      updatePermalink(map, currentMgrsTileId.value, activeTileId.value, secondActiveTileId.value)
-    })
+    shouldUpdate = false
+  })
+}
 
-    // Handle browser back/forward navigation
-    window.addEventListener('popstate', (event) => {
-      if (event.state === null) {
-        return
-      }
+// Update permalink when tile selection changes
+const updateTileSelection = (
+  map: Map,
+  currentMgrsTileId: string | null,
+  activeTileId: string | null,
+  secondActiveTileId: string | null,
+) => {
+  updatePermalink(map, currentMgrsTileId, activeTileId, secondActiveTileId)
+}
 
-      const state = event.state as PermalinkState
-      restoreMapState(map, state)
-
-      // Update the refs
-      currentMgrsTileId.value = state.currentMgrsTileId
-      activeTileId.value = state.activeTileId
-      secondActiveTileId.value = state.secondActiveTileId
-
-      // If we have a restored MGRS tile ID, trigger the search
-      if (state.currentMgrsTileId && onTileRestore) {
-        // Prepare search settings from permalink
-        const searchSettings = {
-          startDate: state.startDate || '',
-          endDate: state.endDate || '',
-          cloudCover: state.cloudCover || 10,
-          areaCoverage: state.areaCoverage || 60,
-        }
-
-        onTileRestore(state.currentMgrsTileId, searchSettings)
-      }
-
-      shouldUpdate.value = false
-    })
-  }
-
-  // Update permalink when tile selection changes
-  const updateTileSelection = (
-    map: Map,
-    currentMgrsTileId: string | null,
-    activeTileId: string | null,
-    secondActiveTileId: string | null,
-  ) => {
-    updatePermalink(map, currentMgrsTileId, activeTileId, secondActiveTileId)
-  }
-
-  return {
-    parsePermalink,
-    updatePermalink,
-    restoreMapState,
-    setupPermalink,
-    updateTileSelection,
-  }
+export function usePermalink() {
+  return { setupPermalink }
 }

--- a/src/composables/usePermalink.ts
+++ b/src/composables/usePermalink.ts
@@ -3,12 +3,14 @@ import type Map from 'ol/Map'
 import {
   activeTileId,
   currentMgrsTileId,
+  drawnExtent,
   secondActiveTileId,
   triggerTileSelection,
 } from './useAreaOfInterest'
 import { map, areaValues } from './useMap'
 import { handleSearchResults } from './useSearch'
-import { fromLonLat, toLonLat } from 'ol/proj'
+import { fromLonLat, toLonLat, transformExtent } from 'ol/proj'
+import { Extent } from 'ol/extent'
 
 export interface PermalinkState {
   zoom: number
@@ -16,6 +18,7 @@ export interface PermalinkState {
   currentMgrsTileId: string | null
   activeTileId: string | null
   secondActiveTileId: string | null
+  bbox?: Extent
   // Search settings - only included when currentMgrsTileId is present
   startDate?: string
   endDate?: string
@@ -76,6 +79,8 @@ const parsePermalink = (): PermalinkState => {
           result.cloudCover = Number(part.substring(12))
         } else if (part.startsWith('area_coverage:')) {
           result.areaCoverage = Number(part.substring(14))
+        } else if (part.startsWith('bbox:')) {
+          result.bbox = part.substring(5).split(',').map(Number)
         }
       }
 
@@ -91,6 +96,7 @@ const parsePermalink = (): PermalinkState => {
 // Update permalink in URL
 const updatePermalink = (
   map: Map,
+  drawnExtent: Extent | null,
   currentMgrsTileId: string | null,
   activeTileId: string | null,
   secondActiveTileId: string | null,
@@ -107,18 +113,26 @@ const updatePermalink = (
 
   const center = toLonLat(viewCenter)
 
-  // Build hash parts, excluding null values
-  const hashParts = [zoom.toFixed(2), center[1].toFixed(5), center[0].toFixed(5)]
+  const extent = drawnExtent
+    ? transformExtent(drawnExtent, 'EPSG:3857', 'EPSG:4326').map((coord) =>
+        Number(coord.toFixed(4)),
+      )
+    : null
 
-  // Only add non-null tile IDs to the hash
+  // Build hash parts, excluding null values
+  const hashParts = [zoom.toFixed(2), center[1].toFixed(4), center[0].toFixed(4)]
+
   if (currentMgrsTileId) {
+    // Add tile IDs
     hashParts.push(currentMgrsTileId)
     hashParts.push(String(activeTileId))
     hashParts.push(String(secondActiveTileId))
-  }
 
-  // If we have a currentMgrsTileId, include search settings
-  if (currentMgrsTileId) {
+    if (extent) {
+      hashParts.push(`bbox:${extent.join(',')}`)
+    }
+
+    // If we have a currentMgrsTileId, include search settings
     const stored = localStorage.getItem('ftw-search-settings')
     if (stored) {
       try {
@@ -143,6 +157,7 @@ const updatePermalink = (
     currentMgrsTileId,
     activeTileId,
     secondActiveTileId,
+    bbox: extent || undefined,
   }
   window.history.pushState(state, 'map', hash)
 }
@@ -160,7 +175,7 @@ const restoreMapState = (map: Map, state: PermalinkState) => {
 }
 
 // Setup permalink functionality
-const setupPermalink = () => {
+const setupPermalink = async () => {
   if (!map.value) {
     throw new Error('Map is not initialized yet')
   }
@@ -170,7 +185,13 @@ const setupPermalink = () => {
   registered = true
 
   watch(
-    () => [map.value, currentMgrsTileId.value, activeTileId.value, secondActiveTileId.value],
+    () => [
+      map.value,
+      drawnExtent.value,
+      currentMgrsTileId.value,
+      activeTileId.value,
+      secondActiveTileId.value,
+    ],
     () => {
       if (!map.value) {
         return
@@ -178,6 +199,7 @@ const setupPermalink = () => {
       // Update permalink after tile selection changes
       updateTileSelection(
         map.value,
+        drawnExtent.value,
         currentMgrsTileId.value,
         activeTileId.value,
         secondActiveTileId.value,
@@ -196,21 +218,24 @@ const setupPermalink = () => {
 
   // If we have a restored MGRS tile ID, trigger the search
   if (initialState.currentMgrsTileId) {
-    // Use setTimeout to ensure the map is fully initialized
-    setTimeout(() => {
-      triggerTileSelection(
-        map.value!,
-        currentMgrsTileId.value!,
-        areaValues.value!,
-        handleSearchResults,
-      )
-    }, 100)
+    await triggerTileSelection(
+      map.value!,
+      currentMgrsTileId.value!,
+      areaValues.value!,
+      handleSearchResults,
+      undefined,
+      false,
+    )
+  }
+  if (initialState.bbox) {
+    drawnExtent.value = transformExtent(initialState.bbox, 'EPSG:4326', 'EPSG:3857')
   }
 
   // Update permalink when map moves
   map.value.on('moveend', () => {
     updatePermalink(
       map.value!,
+      drawnExtent.value,
       currentMgrsTileId.value,
       activeTileId.value,
       secondActiveTileId.value,
@@ -238,6 +263,8 @@ const setupPermalink = () => {
         currentMgrsTileId.value!,
         areaValues.value!,
         handleSearchResults,
+        undefined,
+        false,
       )
     }
 
@@ -248,11 +275,12 @@ const setupPermalink = () => {
 // Update permalink when tile selection changes
 const updateTileSelection = (
   map: Map,
+  drawnExtent: Extent | null,
   currentMgrsTileId: string | null,
   activeTileId: string | null,
   secondActiveTileId: string | null,
 ) => {
-  updatePermalink(map, currentMgrsTileId, activeTileId, secondActiveTileId)
+  updatePermalink(map, drawnExtent, currentMgrsTileId, activeTileId, secondActiveTileId)
 }
 
 export function usePermalink() {

--- a/src/composables/useProcessingMode.ts
+++ b/src/composables/useProcessingMode.ts
@@ -1,0 +1,11 @@
+import { ref } from 'vue'
+
+export const processingMode = ref<'smallAreaProcessing' | 'batchProcessing' | null>(
+  'smallAreaProcessing',
+)
+
+export function useProcessingMode() {
+  return {
+    processingMode,
+  }
+}

--- a/src/composables/useSearch.ts
+++ b/src/composables/useSearch.ts
@@ -40,34 +40,33 @@ export const handleSearchResults = async (
 
   currentBbox.value = bbox
 
+  const performSearch = async () => {
+    settings.collections = selectedCollection.value
+    try {
+      const response = await searchStacApi(bbox, true, settings)
+      if (response) {
+        searchResults.value = response.results
+        hasMore.value = response.hasMore
+
+        if (response.results.length === 0) {
+          searchStatus.value = `No images found. Try adjusting your filters (date range, cloud cover, area coverage) to increase the likelihood of finding results.`
+        } else {
+          searchStatus.value = `Found ${response.results.length} images`
+        }
+      }
+    } catch (error: unknown) {
+      console.error('DataCabinet: Error searching:', error)
+      searchStatus.value = `Error searching: ${error instanceof Error ? error.message : 'Unknown error'}`
+    } finally {
+      isLoading.value = false
+    }
+  }
+  await performSearch()
+
   if (unwatch) {
     unwatch()
   }
-  unwatch = watch(
-    selectedCollection,
-    async (newCollection) => {
-      settings.collections = newCollection
-      try {
-        const response = await searchStacApi(bbox, true, settings)
-        if (response) {
-          searchResults.value = response.results
-          hasMore.value = response.hasMore
-
-          if (response.results.length === 0) {
-            searchStatus.value = `No images found. Try adjusting your filters (date range, cloud cover, area coverage) to increase the likelihood of finding results.`
-          } else {
-            searchStatus.value = `Found ${response.results.length} images`
-          }
-        }
-      } catch (error: unknown) {
-        console.error('DataCabinet: Error searching:', error)
-        searchStatus.value = `Error searching: ${error instanceof Error ? error.message : 'Unknown error'}`
-      } finally {
-        isLoading.value = false
-      }
-    },
-    { immediate: true },
-  )
+  unwatch = watch(selectedCollection, performSearch)
 }
 
 export const clearSearchResults = () => {

--- a/src/composables/useSearch.ts
+++ b/src/composables/useSearch.ts
@@ -16,6 +16,8 @@ export interface SearchResult {
 
 export type SearchResults = Ref<SearchResult[]>
 
+export const searchResults = ref<SearchResult[]>([])
+
 const availableCollections = [['sentinel-2-c1-l2a'], ['sentinel-2-l2a']]
 
 const hasMore = ref(false)
@@ -23,13 +25,12 @@ const isLoading = ref(false)
 const searchStatus = ref('')
 /** Grid extent, reduced by shrink factor (70% of grid extent) */
 const currentBbox = ref<number[] | undefined>(undefined)
-const searchResults = ref<SearchResult[]>([])
 const selectedCollection = ref<string[]>(availableCollections[0])
 
 let unwatch: () => void
 
 // Function to handle search results
-const handleSearchResults = async (
+export const handleSearchResults = async (
   mgrsTileId: string,
   bbox?: number[],
   settings: SearchSettings = {} as SearchSettings,
@@ -69,7 +70,7 @@ const handleSearchResults = async (
   )
 }
 
-const clearSearchResults = () => {
+export const clearSearchResults = () => {
   searchResults.value = []
   hasMore.value = false
   isLoading.value = false


### PR DESCRIPTION
Supersedes and closes #109 
Fixes #107 

Implements the refactoring mentioned in #102, but leaves `usePermalink()` as composable. I've introduced a composable pattern we frequently use at w3geo: export a `use*()` function for use in components, and separate exports for state `ref`s and functions for use in other composables.