### PR TITLE
change wording for win a and win b selection in the cabinet

### DIFF
--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -795,7 +795,7 @@ onUnmounted(() => {
 
         <div v-if="currentMgrsTileId && searchResults.length > 0" class="results-container">
           <div class="accordion-header" @click="toggleFirstResults">
-            <h3 class="active-tile-id">{{ activeTileId ? activeTileId : 'Select a tile' }}</h3>
+            <h3 class="active-tile-id">{{ activeTileId ? activeTileId : 'Select Win A' }}</h3>
             <span class="accordion-icon" :class="{ open: isFirstResultsOpen }">▼</span>
           </div>
 
@@ -846,7 +846,7 @@ onUnmounted(() => {
               :class="{ disabled: !activeTileId }"
             >
               <h3 class="active-tile-id">
-                {{ secondActiveTileId ? secondActiveTileId : 'Select a Second Tile' }}
+                {{ secondActiveTileId ? secondActiveTileId : 'Select Win B' }}
               </h3>
               <span class="accordion-icon" :class="{ open: isSecondResultsOpen }">▼</span>
             </div>


### PR DESCRIPTION
#116 

Resolves the remaining issues in issue 116

Updated the wording in the cabinet to say Select Win A and Select Win B

The remaining two issues seem to be resolved already in another PR