### PR TITLE
Format numbers (easier to read, local), no unit for count.

### DIFF
--- a/src/components/ProcessingResults.vue
+++ b/src/components/ProcessingResults.vue
@@ -36,7 +36,7 @@
           <v-expansion-panel-text>
             <div v-for="field in statFields" class="mb-4">
               <v-label class="text-capitalize mb-1">{{ field }}</v-label>
-              <PropertiesDisplay :properties="statistics[field]" :unit="statUnits[field]" />
+              <PropertiesDisplay :properties="statistics[field]" :units="statUnits[field]" />
             </div>
           </v-expansion-panel-text>
         </v-expansion-panel>
@@ -146,9 +146,9 @@ interface ResaultStats {
 }
 
 const statFields: ('area' | 'perimeter')[] = ['area', 'perimeter']
-const statUnits: Record<'area' | 'perimeter', string> = {
-  area: 'ha',
-  perimeter: 'km',
+const statUnits: Record<'area' | 'perimeter', (key: string | number) => string> = {
+  area: (key) => (key === 'count' ? '' : 'ha'),
+  perimeter: (key) => (key === 'count' ? '' : 'km'),
 }
 
 const statistics = computed(() => {

--- a/src/components/PropertiesDisplay.vue
+++ b/src/components/PropertiesDisplay.vue
@@ -14,7 +14,7 @@
         class="text-caption text-white text-right"
         style="max-width: 120px; word-break: break-word"
       >
-        {{ formattedValue(key, value, props.unit) }}
+        {{ formattedValue(key, value) }}
       </div>
     </template>
   </v-list-item>
@@ -25,7 +25,7 @@ import { computed } from 'vue'
 
 const props = defineProps<{
   properties: { [key: string]: any }
-  unit?: string
+  units?: (key: string | number) => string
 }>()
 
 const propertiesWithoutGeometry = computed(() => {
@@ -33,19 +33,24 @@ const propertiesWithoutGeometry = computed(() => {
   return propertiesWithoutGeometry
 })
 
-function formattedValue(key: string | number, value: any, unit?: string): string {
+const formatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 2,
+})
+
+function formattedValue(key: string | number, value: any): string {
   if (typeof value !== 'number') {
     return value
   }
 
-  if (typeof unit === 'string') {
-    return `${value.toFixed(2)} ${unit}`
+  const formatted = formatter.format(value)
+  if (typeof props.units === 'function') {
+    return `${formatted} ${props.units(key)}`
   } else if (key === 'area') {
-    return `${value.toFixed(2)} ha`
+    return `${formatted} ha`
   } else if (key === 'perimeter') {
-    return `${value.toFixed(2)} km`
+    return `${formatted} km`
   }
-  return `${value.toFixed(2)}`
+  return `${formatted}`
 }
 </script>
 


### PR DESCRIPTION
- Format numbers (large numbers are easier to read, use local formatting rules)
- No unit for "count"

Example (with a German locale): 
<img width="613" height="833" alt="{1C597D6F-C063-4D7F-9369-8753FC06F43B}" src="https://github.com/user-attachments/assets/669ee1e2-300d-4827-b7d1-16592198cc17" />
