### PR TITLE
Get rid of 'imagery' selection tab #197

### DIFF
--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -35,8 +35,7 @@ const { showError, showSuccess } = useNotifier()
 const { hasMore, isLoading, searchResults, searchStatus, handleSearchResults } = useSearch()
 const { activeTileId, currentBBox, currentBBoxValid, secondActiveTileId, currentMgrsTileId } =
   useAreaOfInterest()
-const { settings, collections, availableCollections, availableModels, modelIsSingleShot } =
-  useSettings()
+const { settings, availableModels, modelIsSingleShot } = useSettings()
 const { isBatchProcessing } = useProcessingMode()
 const { placeSearch, isLoadingPlaces, suggestedPlaces, handleLocationSelected } = useGeocoding()
 const { processBatch, processSmallArea, isProcessing } = useBatchProcessing()
@@ -264,11 +263,6 @@ watch(sceneSelectionStatus, (newValue) => {
   }
 })
 watch(map, () => loadAvailableTiles())
-
-const collectionTitle = computed(() => {
-  const collection = settings.value.collection[0]
-  return collection ? collections[collection] : null
-})
 
 const modelTitle = computed(() => {
   const model = settings.value.model
@@ -518,32 +512,6 @@ const getStatus = (condition: any, warn: boolean = false) => {
                   content="Recommended"
                 ></v-badge> </template
             ></v-radio>
-          </v-radio-group>
-        </v-expansion-panel-text>
-      </v-expansion-panel>
-      <!-- Data Collection -->
-      <v-expansion-panel v-if="currentMgrsTileId && settings.expertMode" value="data">
-        <v-expansion-panel-title>
-          <span class="header-text">
-            <v-badge v-bind="getStatus(collectionTitle)"></v-badge>
-            Imagery
-            <v-badge
-              v-if="collectionTitle"
-              inline
-              color="teal"
-              :content="collectionTitle"
-            ></v-badge>
-          </span>
-        </v-expansion-panel-title>
-        <v-expansion-panel-text>
-          <v-radio-group v-model="settings.collection" inline hide-details>
-            <v-radio
-              v-for="collection in availableCollections"
-              :key="collection[0]"
-              :label="collections[collection[0]]"
-              :value="collection"
-              color="teal"
-            />
           </v-radio-group>
         </v-expansion-panel-text>
       </v-expansion-panel>

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -8,7 +8,6 @@ export interface Settings {
   cloudCover: number
   areaCoverage: number
   buffer: number
-  collection: string[]
   model: string
   expertMode: boolean
 }
@@ -24,14 +23,6 @@ export interface ModelInfo {
   default?: boolean
 }
 
-const collections: Record<string, string> = {
-  'sentinel-2-c1-l2a': 'Sentinel-2 Level 2A, Collection 1',
-  'sentinel-2-l2a': 'Sentinel-2 Level 2A, Legacy',
-}
-const availableCollections: [keyof typeof collections][] = Object.keys(collections).map((c) => [
-  c,
-]) as [keyof typeof collections][]
-
 const availableModels = shallowRef<ModelInfo[]>([])
 
 // Default settings
@@ -43,7 +34,6 @@ const defaultSettings: Settings = {
   cloudCover: 20,
   areaCoverage: 60,
   buffer: 14,
-  collection: availableCollections[0],
   model: '',
   expertMode: false,
 }
@@ -129,8 +119,6 @@ const modelIsSingleShot = computed(() => {
 export default function useSettings() {
   return {
     settings,
-    collections,
-    availableCollections,
     availableModels,
     defaultSettings,
     defaultModel,

--- a/src/functions/search-stac-api.ts
+++ b/src/functions/search-stac-api.ts
@@ -68,7 +68,6 @@ export interface SearchSettings {
   cloudCover: number
   areaCoverage: number
   buffer: number
-  collection?: string[]
   autoSceneSelection?: boolean
 }
 
@@ -165,7 +164,7 @@ export default async function searchStacApi(
   try {
     // Build request body for POST
     const requestBody: any = {
-      collections: params?.collection || ['sentinel-2-c1-l2a'],
+      collections: ['sentinel-2-c1-l2a'],
       limit: 100,
       query: {
         ['eo:cloud_cover']: {

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -32,8 +32,8 @@ watch(dontShowAgain, (newValue) => {
       <v-card max-width="600" border :prepend-icon="mdiInformation" title="About the Inference App">
         <v-card-text>
           Welcome to the Fields of the World (FTW) Web App. Use it to run the FTW model on
-          Sentinel-2 imagery and generate predicted field boundaries for your chosen area of
-          interest. To get started, either zoom in or click on your area of interest.
+          Sentinel-2 Level 2A Collection 1 imagery and generate predicted field boundaries for your
+          chosen area of interest. To get started, either zoom in or click on your area of interest.
         </v-card-text>
         <v-card-actions>
           <v-checkbox-btn v-model="dontShowAgain" label="Don't show again"></v-checkbox-btn>


### PR DESCRIPTION
Closes #197

If we want it back at some point (e.g. for other collection), we can just revert. Thus removing completely instead of just hiding it.