### PR TITLE
Add settings for inference and polygonization

### DIFF
--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -35,7 +35,7 @@ const { showError, showSuccess } = useNotifier()
 const { hasMore, isLoading, searchResults, searchStatus, handleSearchResults } = useSearch()
 const { activeTileId, currentBBox, currentBBoxValid, secondActiveTileId, currentMgrsTileId } =
   useAreaOfInterest()
-const { settings, availableModels, modelIsSingleShot } = useSettings()
+const { processingSettings, settings, availableModels, modelIsSingleShot } = useSettings()
 const { isBatchProcessing } = useProcessingMode()
 const { placeSearch, isLoadingPlaces, suggestedPlaces, handleLocationSelected } = useGeocoding()
 const { processBatch, processSmallArea, isProcessing } = useBatchProcessing()
@@ -88,6 +88,25 @@ const sceneYears = Array.from({ length: 10 }, (_, i) => new Date().getFullYear()
 const isSelectingScenes = computed(
   () => sceneSelectionStatus.value === null && settings.value.autoSceneSelection,
 )
+
+const patchSizes = [32, 64, 128, 256, 512, 1024, 2048, 4096]
+const patchSizeEnabled = ref(true)
+watch(patchSizeEnabled, (newValue) => {
+  if (newValue) {
+    processingSettings.value.inference_patch_size = null
+  } else {
+    processingSettings.value.inference_patch_size = 256
+  }
+})
+
+const paddingEnabled = ref(true)
+watch(paddingEnabled, (newValue) => {
+  if (newValue) {
+    processingSettings.value.inference_padding = null
+  } else {
+    processingSettings.value.inference_padding = 64
+  }
+})
 
 let abortController: AbortController | null = null
 watch(
@@ -676,7 +695,6 @@ const getStatus = (condition: any, warn: boolean = false) => {
                 :items="months"
                 label=" Start Month"
                 variant="outlined"
-                density="compact"
                 hide-details
                 :disabled="settings.autoSceneSelection"
                 item-value="value"
@@ -689,7 +707,6 @@ const getStatus = (condition: any, warn: boolean = false) => {
                 :items="months"
                 label="End Month"
                 variant="outlined"
-                density="compact"
                 hide-details
                 :disabled="settings.autoSceneSelection"
                 item-value="value"
@@ -750,7 +767,7 @@ const getStatus = (condition: any, warn: boolean = false) => {
           <!-- Cloud Coverage -->
           <v-row>
             <v-col cols="6">
-              <v-label class="text-subtitle-2">Cloud Cover (%)</v-label>
+              <v-label>Cloud Cover (%)</v-label>
             </v-col>
             <v-col cols="6" class="d-flex justify-end">
               <v-number-input
@@ -792,7 +809,7 @@ const getStatus = (condition: any, warn: boolean = false) => {
           <!-- Area Coverage -->
           <v-row>
             <v-col cols="6">
-              <v-label class="text-subtitle-2">
+              <v-label>
                 <template v-if="settings.autoSceneSelection">Search Buffer (days)</template>
                 <template v-else>Area Coverage (%)</template>
               </v-label>
@@ -1051,6 +1068,208 @@ const getStatus = (condition: any, warn: boolean = false) => {
             <template v-else>Load more</template>
           </v-btn>
         </div>
+      </v-expansion-panel>
+      <!-- Inference -->
+      <v-expansion-panel v-if="settings.expertMode && currentMgrsTileId" value="inference">
+        <v-expansion-panel-title>
+          <span class="header-text">
+            <v-badge v-bind="getStatus(true)"></v-badge>
+            Inference Settings
+          </span>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <!-- resize_factor -->
+          <v-row>
+            <v-col cols="7">
+              <v-label>Resize factor</v-label>
+            </v-col>
+            <v-col cols="5" class="d-flex justify-end">
+              <v-number-input
+                v-model.number="processingSettings.inference_resize_factor"
+                :min="1"
+                :max="5"
+                :step="1"
+                :precision="0"
+                density="compact"
+                variant="outlined"
+                control-variant="stacked"
+                hide-details
+                class="coverage-input"
+              ></v-number-input>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-slider
+                v-model.number="processingSettings.inference_resize_factor"
+                :min="1"
+                :max="5"
+                :step="1"
+                color="teal"
+                track-color="grey-darken-2"
+                thumb-color="teal"
+                hide-details
+              />
+            </v-col>
+          </v-row>
+          <!-- patch_size -->
+          <v-row>
+            <v-col>
+              <v-checkbox v-model="patchSizeEnabled" density="compact" hide-details
+                ><template v-slot:label>Automatic patch size</template>
+              </v-checkbox>
+            </v-col>
+          </v-row>
+          <v-row v-if="!patchSizeEnabled">
+            <v-col>
+              <v-select
+                v-model.number="processingSettings.inference_patch_size"
+                label="Patch Size (must be a power of 2)"
+                :items="patchSizes"
+                variant="outlined"
+                hide-details
+              ></v-select>
+            </v-col>
+          </v-row>
+          <!-- padding -->
+          <template v-if="!modelTitle?.includes('DelineateAnything')">
+            <v-row>
+              <v-col :cols="paddingEnabled ? 12 : 7">
+                <v-checkbox v-model="paddingEnabled" density="compact" hide-details
+                  ><template v-slot:label>Automatic padding</template>
+                </v-checkbox>
+              </v-col>
+              <v-col
+                v-if="processingSettings.inference_padding !== null"
+                cols="5"
+                class="d-flex justify-end"
+              >
+                <v-number-input
+                  v-model.number="processingSettings.inference_padding"
+                  :min="0"
+                  :max="1024"
+                  :step="1"
+                  :precision="0"
+                  density="compact"
+                  variant="outlined"
+                  control-variant="stacked"
+                  hide-details
+                  class="coverage-input"
+                ></v-number-input>
+              </v-col>
+            </v-row>
+            <v-row v-if="processingSettings.inference_padding !== null">
+              <v-col>
+                <v-slider
+                  v-model.number="processingSettings.inference_padding"
+                  :min="0"
+                  :max="1024"
+                  :step="1"
+                  color="teal"
+                  track-color="grey-darken-2"
+                  thumb-color="teal"
+                  hide-details
+                />
+              </v-col>
+            </v-row>
+          </template>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+      <!-- Polygonization -->
+      <v-expansion-panel
+        v-if="
+          settings.expertMode && currentMgrsTileId && !modelTitle?.includes('DelineateAnything')
+        "
+        value="polygonization"
+      >
+        <v-expansion-panel-title>
+          <span class="header-text">
+            <v-badge v-bind="getStatus(true)"></v-badge>
+            Polygonization Settings
+          </span>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <!-- close_interiors -->
+          <v-row>
+            <v-col>
+              <v-checkbox
+                v-model="processingSettings.polygons_close_interiors"
+                density="compact"
+                hide-details
+              >
+                <template v-slot:label>Remove interior holes in the polygons</template>
+              </v-checkbox>
+            </v-col>
+          </v-row>
+          <!-- min_size -->
+          <v-row>
+            <v-col cols="7">
+              <v-label>Min. field size in m²</v-label>
+            </v-col>
+            <v-col cols="5" class="d-flex justify-end">
+              <v-number-input
+                v-model.number="processingSettings.polygons_min_size"
+                :min="100"
+                :max="10000"
+                :step="10"
+                :precision="0"
+                density="compact"
+                variant="outlined"
+                control-variant="stacked"
+                hide-details
+                class="coverage-input"
+              ></v-number-input>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-slider
+                v-model.number="processingSettings.polygons_min_size"
+                :min="100"
+                :max="10000"
+                :step="10"
+                color="teal"
+                track-color="grey-darken-2"
+                thumb-color="teal"
+                hide-details
+              />
+            </v-col>
+          </v-row>
+          <!-- simplify -->
+          <v-row>
+            <v-col cols="7">
+              <v-label>Simplification factor in meters</v-label>
+            </v-col>
+            <v-col cols="5" class="d-flex justify-end">
+              <v-number-input
+                v-model.number="processingSettings.polygons_simplify"
+                :min="5"
+                :max="100"
+                :step="1"
+                :precision="0"
+                density="compact"
+                variant="outlined"
+                control-variant="stacked"
+                hide-details
+                class="coverage-input"
+              ></v-number-input>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-slider
+                v-model.number="processingSettings.polygons_simplify"
+                :min="5"
+                :max="100"
+                :step="1"
+                color="teal"
+                track-color="grey-darken-2"
+                thumb-color="teal"
+                hide-details
+              />
+            </v-col>
+          </v-row>
+        </v-expansion-panel-text>
       </v-expansion-panel>
     </v-expansion-panels>
   </div>

--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -341,24 +341,6 @@ const loadMore = async () => {
   }
 }
 
-const updateCloudCoverInput = () => {
-  // Ensure the value is a number and not below 1
-  const value = Number(settings.value.cloudCover)
-  settings.value.cloudCover = Math.max(1, value)
-}
-
-const updateAreaCoverageInput = () => {
-  // Ensure the value is a number and not below 1
-  const value = Number(settings.value.areaCoverage)
-  settings.value.areaCoverage = Math.max(1, value)
-}
-
-const updateBufferInput = () => {
-  // Ensure the value is a number and not below 1
-  const value = Number(settings.value.buffer)
-  settings.value.buffer = Math.max(1, value)
-}
-
 // Handle tile selection from search modal
 const handleTileSelected = (tileName: string) => {
   // Find the tile feature on the map and trigger the tile selection
@@ -772,8 +754,7 @@ const getStatus = (condition: any, warn: boolean = false) => {
             </v-col>
             <v-col cols="6" class="d-flex justify-end">
               <v-number-input
-                v-model="settings.cloudCover"
-                @update:model-value="updateCloudCoverInput"
+                v-model.number="settings.cloudCover"
                 :min="1"
                 :max="100"
                 :step="1"
@@ -789,7 +770,7 @@ const getStatus = (condition: any, warn: boolean = false) => {
           <v-row>
             <v-col>
               <v-slider
-                v-model="settings.cloudCover"
+                v-model.number="settings.cloudCover"
                 :min="1"
                 :max="100"
                 :step="1"
@@ -797,7 +778,6 @@ const getStatus = (condition: any, warn: boolean = false) => {
                 track-color="grey-darken-2"
                 thumb-color="teal"
                 hide-details
-                @update:model-value="updateCloudCoverInput"
               />
             </v-col>
           </v-row>
@@ -821,8 +801,7 @@ const getStatus = (condition: any, warn: boolean = false) => {
             <v-col cols="6" class="d-flex justify-end">
               <v-number-input
                 v-if="settings.autoSceneSelection"
-                v-model="settings.buffer"
-                @update:model-value="updateBufferInput"
+                v-model.number="settings.buffer"
                 :min="1"
                 :max="60"
                 :step="1"
@@ -835,8 +814,7 @@ const getStatus = (condition: any, warn: boolean = false) => {
               ></v-number-input>
               <v-number-input
                 v-else
-                v-model="settings.areaCoverage"
-                @update:model-value="updateAreaCoverageInput"
+                v-model.number="settings.areaCoverage"
                 :min="1"
                 :max="100"
                 :step="1"
@@ -853,8 +831,7 @@ const getStatus = (condition: any, warn: boolean = false) => {
             <v-col>
               <v-slider
                 v-if="settings.autoSceneSelection"
-                v-model="settings.buffer"
-                @update:model-value="updateBufferInput"
+                v-model.number="settings.buffer"
                 :min="1"
                 :max="60"
                 :step="1"
@@ -865,8 +842,7 @@ const getStatus = (condition: any, warn: boolean = false) => {
               />
               <v-slider
                 v-else
-                v-model="settings.areaCoverage"
-                @update:model-value="updateAreaCoverageInput"
+                v-model.number="settings.areaCoverage"
                 :min="1"
                 :max="100"
                 :step="1"

--- a/src/composables/useProcessing.ts
+++ b/src/composables/useProcessing.ts
@@ -13,7 +13,7 @@ export default function useProcessing() {
   const { currentBBox, isBBox } = useAreaOfInterest()
   const { fitMapToBbox, displayGeoJSON } = useMap()
   const { showError, showSuccess, showInfo, showWarning } = useNotifier()
-  const { settings, modelIsSingleShot } = useSettings()
+  const { settings, inferenceSettings, polygonizationSettings, modelIsSingleShot } = useSettings()
   const { stacPreviewTileId } = useStacLayer()
 
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
@@ -144,10 +144,9 @@ export default function useProcessing() {
                 ? [firstTile?.itemUrl]
                 : [firstTile?.itemUrl, secondTile?.itemUrl],
               bbox: currentBBox.value,
+              ...inferenceSettings.value,
             },
-            polygons: {
-              close_interiors: true,
-            },
+            polygons: polygonizationSettings.value,
           }),
         })
       })
@@ -224,6 +223,7 @@ export default function useProcessing() {
             images: modelIsSingleShot.value
               ? [firstTile?.itemUrl]
               : [firstTile?.itemUrl, secondTile?.itemUrl],
+            ...inferenceSettings.value,
           }),
         })
       })
@@ -238,9 +238,7 @@ export default function useProcessing() {
           return await fetch(`${apiBaseUrl}projects/${projectId}/polygons`, {
             method: 'PUT',
             headers: createHeaders(),
-            body: JSON.stringify({
-              close_interiors: true,
-            }),
+            body: JSON.stringify(polygonizationSettings.value),
           })
         })
       }

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -12,6 +12,15 @@ export interface Settings {
   expertMode: boolean
 }
 
+export interface ProcessingSettings {
+  inference_resize_factor: number
+  inference_patch_size: number | null
+  inference_padding: number | null
+  polygons_simplify: number
+  polygons_min_size: number
+  polygons_close_interiors: boolean
+}
+
 export interface ModelInfo {
   id: string
   title: string
@@ -38,6 +47,33 @@ const defaultSettings: Settings = {
   expertMode: false,
 }
 
+// Default processing settings
+const defaultProcessingSettings: ProcessingSettings = {
+  inference_resize_factor: 2,
+  inference_patch_size: null,
+  inference_padding: null,
+  polygons_simplify: 15,
+  polygons_min_size: 500,
+  polygons_close_interiors: false,
+}
+
+function filterProcessingSettings(prefix: string) {
+  const data = {}
+  for (const key in processingSettings.value) {
+    if (key.startsWith(prefix)) {
+      const value = (processingSettings.value as any)[key]
+      if (value !== (defaultProcessingSettings as any)[key]) {
+        ;(data as any)[key.substring(prefix.length)] = value
+      }
+    }
+  }
+  return data
+}
+
+const inferenceSettings = computed(() => filterProcessingSettings('inference_'))
+
+const polygonizationSettings = computed(() => filterProcessingSettings('polygons_'))
+
 const defaultModel = computed(() => {
   let selected = availableModels.value.find((m) => m.default)
   if (!selected && availableModels.value.length > 0) {
@@ -52,17 +88,25 @@ watch(defaultModel, () => {
   }
 })
 
-const loadSettingsFromStorage = (): Settings => {
-  const stored = localStorage.getItem('ftw-search-settings')
+const loadSettingsFromStorage = (key: string, defaults: object): object => {
+  const stored = localStorage.getItem(key)
   if (stored) {
     const parsed = JSON.parse(stored)
-    return Object.assign(structuredClone(defaultSettings), parsed) as Settings
+    return Object.assign(structuredClone(defaults), parsed)
   }
 
-  return structuredClone(defaultSettings)
+  return structuredClone(defaults)
 }
 
-const settings = ref<Settings>(loadSettingsFromStorage())
+const settings = ref<Settings>(
+  loadSettingsFromStorage('ftw-search-settings', defaultSettings) as Settings,
+)
+const processingSettings = ref<ProcessingSettings>(
+  loadSettingsFromStorage(
+    'ftw-processing-settings',
+    defaultProcessingSettings,
+  ) as ProcessingSettings,
+)
 
 // Function to set available models from API response
 const setAvailableModels = (modelsData: ModelInfo[]) => {
@@ -111,6 +155,14 @@ watch(
   { deep: true },
 )
 
+watch(
+  processingSettings,
+  (newProcessingSettings) => {
+    localStorage.setItem('ftw-processing-settings', JSON.stringify(newProcessingSettings))
+  },
+  { deep: true },
+)
+
 const modelIsSingleShot = computed(() => {
   const model = availableModels.value.find((m) => m.id === settings.value.model)
   return model?.requires_window === false
@@ -119,8 +171,12 @@ const modelIsSingleShot = computed(() => {
 export default function useSettings() {
   return {
     settings,
+    processingSettings,
+    inferenceSettings,
+    polygonizationSettings,
     availableModels,
     defaultSettings,
+    defaultProcessingSettings,
     defaultModel,
     loadSettingsFromStorage,
     setAvailableModels,


### PR DESCRIPTION
Supported settings as specified in the OpenAPI document of the ftw-inference-api respository.

Adds for inference:
- resize_factor
- patch_size
- padding (disabled for delineate anything)

Adds for polygonization (partially closes #210, all disabled for delineate anything):
- simplify 
- min_size (closes #183)
- close_interiors

Based on #220 