### PR TITLE
Issue 209 Turn on scene a by default when auto-scene selection results are recieved

### DIFF
--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -270,7 +270,7 @@ watch(sceneSelectionStatus, (newValue) => {
 })
 
 // Display Scene A image by default when auto scene selection is enabled and a scene is selected
-watch([() => settings.value.autoSceneSelection, activeTileId], ([autoSelection, tileId]) => {
+watch([settings.value.autoSceneSelection, activeTileId], ([autoSelection, tileId]) => {
   if (autoSelection && tileId) {
     stacPreviewTileId.value = tileId
   }


### PR DESCRIPTION
When the user has auto scene selection enabled the Win A that is selected will be displayed when available. This doesn't display scene A by default when auto scene selection is not enabled.