### PR TITLE
Change km to m

### DIFF
--- a/src/components/ProcessingResults.vue
+++ b/src/components/ProcessingResults.vue
@@ -168,7 +168,7 @@ interface ResaultStats {
 const statFields: ('area' | 'perimeter')[] = ['area', 'perimeter']
 const statUnits: Record<'area' | 'perimeter', (key: string | number) => string> = {
   area: (key) => (key === 'count' ? '' : 'ha'),
-  perimeter: (key) => (key === 'count' ? '' : 'km'),
+  perimeter: (key) => (key === 'count' ? '' : 'm'),
 }
 
 const statistics = computed(() => {

--- a/src/components/PropertiesDisplay.vue
+++ b/src/components/PropertiesDisplay.vue
@@ -48,7 +48,7 @@ function formattedValue(key: string | number, value: any): string {
   } else if (key === 'area') {
     return `${formatted} ha`
   } else if (key === 'perimeter') {
-    return `${formatted} km`
+    return `${formatted} m`
   }
   return `${formatted}`
 }


### PR DESCRIPTION
The unit of the perimeter column in the response is meters, not kilometers.