### PR TITLE
Update global predictions layers

### DIFF
--- a/src/components/MapLegend.vue
+++ b/src/components/MapLegend.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { mdiMapLegend } from '@mdi/js'
+import useMap from '../composables/useMap'
 import useSettings from '../composables/useSettings'
 import { GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL } from '../composables/useSettings'
-import { map, geoJsonResults } from '../composables/useMap'
-import {
-  areaColorScale,
-  confidenceColorScale,
-  globalPredictionsStyle,
-  inferenceStyle,
-} from '../layers/color-scales'
+import { areaColorScale, confidenceColorScale, inferenceStyle } from '../layers/color-scales'
 
 const { settings } = useSettings()
+const { map, geoJsonResults } = useMap()
 
 const collapsed = ref(true)
 const zoom = ref(0)
@@ -34,22 +30,33 @@ onUnmounted(() => {
 const showFields = computed(() => zoom.value >= GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL)
 const hasInferenceResults = computed(() => geoJsonResults.value.length > 0)
 
-const stops = computed(() =>
-  settings.value.aggregate === 'confidence' ? confidenceColorScale : areaColorScale,
+// When zoomed in, always use the confidence scale; zoomed out, use whichever aggregate is selected
+const legendStops = computed(() =>
+  showFields.value || settings.value.aggregate === 'confidence'
+    ? confidenceColorScale
+    : areaColorScale,
 )
-const title = computed(() =>
-  settings.value.aggregate === 'confidence' ? 'Confidence (%)' : 'Field Area (%)',
+const legendTitle = computed(() =>
+  showFields.value || settings.value.aggregate === 'confidence'
+    ? 'Confidence (%)'
+    : 'Field Area (%)',
+)
+const legendShowThreshold = computed(
+  () => showFields.value || settings.value.aggregate === 'confidence',
 )
 
-const isConfidence = computed(() => settings.value.aggregate === 'confidence')
+const legendRampGradient = computed(() => {
+  const s = legendStops.value
+  const n = s.length - 1
+  const colorStops = s.map((stop, i) => `${stop.color} ${(i / n) * 100}%`)
+  return `linear-gradient(to right, ${colorStops.join(', ')})`
+})
 
-// Compute threshold position based on evenly-spaced stop indices (matching label layout)
-const thresholdPct = computed(() => {
-  if (!isConfidence.value) return 0
-  const s = stops.value
+const legendThresholdPct = computed(() => {
+  if (!legendShowThreshold.value) return 0
+  const s = legendStops.value
   const threshold = settings.value.threshold
   const n = s.length - 1
-  // Find which segment the threshold falls in
   for (let i = 0; i < n; i++) {
     if (threshold <= s[i].value) return (i / n) * 100
     if (threshold <= s[i + 1].value) {
@@ -58,14 +65,6 @@ const thresholdPct = computed(() => {
     }
   }
   return 100
-})
-
-const rampStyle = computed(() => {
-  // Always use evenly-spaced full ramp
-  const s = stops.value
-  const n = s.length - 1
-  const colorStops = s.map((stop, i) => `${stop.color} ${(i / n) * 100}%`)
-  return { background: `linear-gradient(to right, ${colorStops.join(', ')})` }
 })
 </script>
 
@@ -85,17 +84,6 @@ const rampStyle = computed(() => {
       </svg>
     </button>
     <div v-show="!collapsed" class="ol-legend-content">
-      <!-- Global predictions swatch (zoomed in) -->
-      <div v-if="settings.mode === 'global' && showFields" class="ol-legend-item">
-        <span
-          class="ol-legend-swatch"
-          :style="{
-            backgroundColor: globalPredictionsStyle.fill,
-            borderColor: globalPredictionsStyle.stroke,
-          }"
-        ></span>
-        <span>{{ globalPredictionsStyle.label }}</span>
-      </div>
       <!-- Inference results swatch -->
       <div v-if="hasInferenceResults" class="ol-legend-item">
         <span
@@ -107,19 +95,33 @@ const rampStyle = computed(() => {
         ></span>
         <span>{{ inferenceStyle.label }}</span>
       </div>
-      <!-- Overview ramp legend (global mode, zoomed out) -->
-      <template v-if="settings.mode === 'global' && settings.aggregate && !showFields">
-        <div class="ol-legend-title">{{ title }}</div>
+      <!-- Global fields swatch -->
+      <div v-if="showFields" class="ol-legend-item">
+        <span
+          class="ol-legend-swatch"
+          :style="{
+            background: 'transparent',
+            borderImage: `${legendRampGradient} 2`,
+          }"
+        ></span>
+        <span>Global Predictions</span>
+      </div>
+      <!-- Color ramp legend -->
+      <template v-if="showFields || settings.aggregate">
+        <div class="ol-legend-title" :class="{ showFields }">
+          <template v-if="showFields">with colors based on confidence:</template>
+          <template v-else>{{ legendTitle }}</template>
+        </div>
         <div class="ol-legend-bar">
-          <div class="ol-legend-bar-ramp" :style="rampStyle"></div>
+          <div class="ol-legend-bar-ramp" :style="{ background: legendRampGradient }"></div>
           <div
-            v-if="isConfidence && thresholdPct > 0"
+            v-if="legendThresholdPct > 0"
             class="ol-legend-bar-transparent"
-            :style="{ width: thresholdPct + '%' }"
+            :style="{ width: legendThresholdPct + '%' }"
           ></div>
         </div>
         <div class="ol-legend-labels">
-          <span v-for="(stop, i) in stops" :key="i">{{ stop.label }}</span>
+          <span v-for="(stop, i) in legendStops" :key="i">{{ stop.label }}</span>
         </div>
       </template>
     </div>
@@ -173,6 +175,10 @@ const rampStyle = computed(() => {
   font-weight: 600;
   margin-bottom: 0.35em;
   text-align: center;
+}
+.ol-legend-title.showFields {
+  font-weight: 500;
+  text-align: left;
 }
 
 .ol-legend-bar {

--- a/src/components/__tests__/Map.test.ts
+++ b/src/components/__tests__/Map.test.ts
@@ -12,14 +12,12 @@ vi.mock('../../layers/Global-Predictions-Layer', async () => {
   const { default: VectorTileLayer } = await import('ol/layer/VectorTile')
   return {
     createGlobalPredictionsLayer: vi.fn(() => new VectorTileLayer()),
-    updateGlobalPredictionsLayer: vi.fn(),
   }
 })
 vi.mock('../../layers/Global-Overview-Layers', async () => {
   const { default: GlTileLayer } = await import('ol/layer/WebGLTile.js')
   return {
     createGlobalOverviewLayer: vi.fn(() => new GlTileLayer()),
-    updateGlobalOverviewLayer: vi.fn(),
   }
 })
 

--- a/src/composables/useMap.ts
+++ b/src/composables/useMap.ts
@@ -14,10 +14,7 @@ import useNotifier from './useNotifier'
 import useSettings from './useSettings'
 import createCloudlessLayer from '../layers/S2-Cloudless-Layer'
 import createS2GridLayer from '../layers/S2-Grid-Layer'
-import {
-  createGlobalPredictionsLayer,
-  updateGlobalPredictionsLayer,
-} from '../layers/Global-Predictions-Layer'
+import { createGlobalPredictionsLayer } from '../layers/Global-Predictions-Layer'
 import { Fill, Stroke, Style } from 'ol/style'
 import { type FeatureLike } from 'ol/Feature'
 import {
@@ -73,6 +70,16 @@ watch(
     cloudlessLayer.value = createCloudlessLayer(newYear)
     // Insert at index 0 to keep it as the base layer
     map.value.getLayers().insertAt(0, cloudlessLayer.value)
+
+    if (settings.value.mode === 'global') {
+      if (globalPredictionsLayer.value) {
+        map.value.removeLayer(globalPredictionsLayer.value)
+        globalPredictionsLayer.value = null
+      }
+
+      globalPredictionsLayer.value = createGlobalPredictionsLayer(settings.value)
+      map.value.addLayer(globalPredictionsLayer.value)
+    }
   },
 )
 
@@ -115,15 +122,6 @@ const updateAggregateLayer = () => {
 
 watch(() => settings.value.aggregate, updateAggregateLayer)
 
-watch(
-  () => settings.value.year,
-  () => {
-    if (globalPredictionsLayer.value) {
-      updateGlobalPredictionsLayer(globalPredictionsLayer.value, settings.value.year)
-    }
-  },
-)
-
 const updateLayers = () => {
   if (!map.value) {
     return
@@ -137,7 +135,8 @@ const updateLayers = () => {
 
     // Initialize with global predictions layers
     if (!globalPredictionsLayer.value) {
-      globalPredictionsLayer.value = createGlobalPredictionsLayer(settings.value.year)
+      // Only handle first initialization here, year changes are handled by a watcher on year above
+      globalPredictionsLayer.value = createGlobalPredictionsLayer(settings.value)
       map.value.addLayer(globalPredictionsLayer.value)
     }
     if (settings.value.aggregate) {

--- a/src/composables/useMap.ts
+++ b/src/composables/useMap.ts
@@ -14,7 +14,10 @@ import useNotifier from './useNotifier'
 import useSettings from './useSettings'
 import createCloudlessLayer from '../layers/S2-Cloudless-Layer'
 import createS2GridLayer from '../layers/S2-Grid-Layer'
-import { createGlobalPredictionsLayer } from '../layers/Global-Predictions-Layer'
+import {
+  createGlobalPredictionsLayer,
+  updateGlobalPredictionsLayer,
+} from '../layers/Global-Predictions-Layer'
 import { Fill, Stroke, Style } from 'ol/style'
 import { type FeatureLike } from 'ol/Feature'
 import {
@@ -101,6 +104,9 @@ watch(
   () => {
     if (globalOverviewLayer.value) {
       updateGlobalOverviewLayer(globalOverviewLayer.value, settings.value)
+    }
+    if (globalPredictionsLayer.value) {
+      updateGlobalPredictionsLayer(globalPredictionsLayer.value, settings.value)
     }
   },
 )

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -158,10 +158,12 @@ const modelIsSingleShot = computed(() => {
   return model?.requires_window === false
 })
 
+export const GLOBAL_DATA_PMTILES_THRESHOLD_METRIC = 'median' // median / mean / min
 export const GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL = 13
 export const GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL = 10
-export const GLOBAL_DATA_PMTILES =
-  'https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/tge-labs/ftw-global-data/predictions/vectors/alpha/global.pmtiles'
+export const get_global_pmtiles_url = (year: number) => {
+  return `https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/ftw/global-field-boundaries/pmtiles/ftw-global-fields-${year}.pmtiles`
+}
 
 export const AREA_OVERVIEW_COG =
   'https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/m-mohr/ftw-confidence-layers/prue_v1_field_area_500m_fieldsonly.tif'

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -159,7 +159,7 @@ const modelIsSingleShot = computed(() => {
 })
 
 export const GLOBAL_DATA_PMTILES_THRESHOLD_METRIC = 'median' // median / mean / min
-export const GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL = 13
+export const GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL = 12
 export const GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL = 10
 export const get_global_pmtiles_url = (year: number) => {
   return `https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/ftw/global-field-boundaries/pmtiles/ftw-global-fields-${year}.pmtiles`

--- a/src/layers/Global-Predictions-Layer.ts
+++ b/src/layers/Global-Predictions-Layer.ts
@@ -19,7 +19,11 @@ export function createGlobalPredictionsLayer(settings: Settings) {
       name: `global-predictions`,
     },
   })
+  updateGlobalPredictionsLayer(layer, settings)
+  return layer
+}
 
+export function updateGlobalPredictionsLayer(layer: VectorTileLayer, settings: Settings) {
   const key = `confidence_${GLOBAL_DATA_PMTILES_THRESHOLD_METRIC}`
   const style = new Style({
     stroke: new Stroke({
@@ -31,6 +35,4 @@ export function createGlobalPredictionsLayer(settings: Settings) {
     }),
   })
   layer.setStyle((feature) => (feature.get(key) <= settings.threshold ? undefined : style))
-
-  return layer
 }

--- a/src/layers/Global-Predictions-Layer.ts
+++ b/src/layers/Global-Predictions-Layer.ts
@@ -7,7 +7,7 @@ import {
   get_global_pmtiles_url,
   type Settings,
 } from '../composables/useSettings'
-import { globalPredictionsStyle } from './color-scales'
+import { confidenceColorScale, getColorForValue } from './color-scales'
 
 export function createGlobalPredictionsLayer(settings: Settings) {
   const layer = new VectorTileLayer({
@@ -25,14 +25,17 @@ export function createGlobalPredictionsLayer(settings: Settings) {
 
 export function updateGlobalPredictionsLayer(layer: VectorTileLayer, settings: Settings) {
   const key = `confidence_${GLOBAL_DATA_PMTILES_THRESHOLD_METRIC}`
-  const style = new Style({
-    stroke: new Stroke({
-      color: globalPredictionsStyle.stroke,
-      width: 1,
-    }),
-    fill: new Fill({
-      color: globalPredictionsStyle.fill,
-    }),
+  layer.setStyle((feature) => {
+    const confidence = feature.get(key)
+    if (confidence <= settings.threshold) return undefined
+    return new Style({
+      stroke: new Stroke({
+        color: getColorForValue(confidenceColorScale, confidence, 1),
+        width: 1,
+      }),
+      fill: new Fill({
+        color: getColorForValue(confidenceColorScale, confidence, 0.3),
+      }),
+    })
   })
-  layer.setStyle((feature) => (feature.get(key) <= settings.threshold ? undefined : style))
 }

--- a/src/layers/Global-Predictions-Layer.ts
+++ b/src/layers/Global-Predictions-Layer.ts
@@ -2,39 +2,35 @@ import VectorTileLayer from 'ol/layer/VectorTile'
 import { PMTilesVectorSource } from 'ol-pmtiles'
 import { Fill, Stroke, Style } from 'ol/style'
 import {
+  GLOBAL_DATA_PMTILES_THRESHOLD_METRIC,
   GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL,
-  GLOBAL_DATA_PMTILES,
+  get_global_pmtiles_url,
+  type Settings,
 } from '../composables/useSettings'
 import { globalPredictionsStyle } from './color-scales'
 
-export function createGlobalPredictionsLayer(year: number) {
+export function createGlobalPredictionsLayer(settings: Settings) {
   const layer = new VectorTileLayer({
     source: new PMTilesVectorSource({
-      url: GLOBAL_DATA_PMTILES,
+      url: get_global_pmtiles_url(settings.year),
     }),
     minZoom: GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL,
     properties: {
-      name: 'global-predictions',
+      name: `global-predictions`,
     },
   })
-  updateGlobalPredictionsLayer(layer, year)
-  return layer
-}
 
-export function updateGlobalPredictionsLayer(layer: VectorTileLayer, year: number) {
-  layer.setStyle((feature) => {
-    const layer = feature.get('layer')
-    if (layer === `field-${year}-01-01 00:00:00`) {
-      return new Style({
-        stroke: new Stroke({
-          color: globalPredictionsStyle.stroke,
-          width: 1,
-        }),
-        fill: new Fill({
-          color: globalPredictionsStyle.fill,
-        }),
-      })
-    }
-    return undefined
+  const key = `confidence_${GLOBAL_DATA_PMTILES_THRESHOLD_METRIC}`
+  const style = new Style({
+    stroke: new Stroke({
+      color: globalPredictionsStyle.stroke,
+      width: 1,
+    }),
+    fill: new Fill({
+      color: globalPredictionsStyle.fill,
+    }),
   })
+  layer.setStyle((feature) => (feature.get(key) <= settings.threshold ? undefined : style))
+
+  return layer
 }

--- a/src/layers/color-scales.ts
+++ b/src/layers/color-scales.ts
@@ -17,8 +17,8 @@ export const globalPredictionsStyle: FeatureStyle = {
 }
 
 export const inferenceStyle: FeatureStyle = {
-  fill: 'rgba(255, 255, 0, 0.1)',
-  stroke: 'rgba(255, 255, 0, 1)',
+  fill: 'rgba(0, 255, 255, 0.1)',
+  stroke: 'rgba(0, 255, 255, 0.8)',
   label: 'Inference',
 }
 

--- a/src/layers/color-scales.ts
+++ b/src/layers/color-scales.ts
@@ -10,15 +10,9 @@ export interface FeatureStyle {
   label: string
 }
 
-export const globalPredictionsStyle: FeatureStyle = {
-  fill: 'rgba(255, 100, 0, 0.2)',
-  stroke: 'rgba(255, 100, 0, 0.8)',
-  label: 'Global Predictions',
-}
-
 export const inferenceStyle: FeatureStyle = {
   fill: 'rgba(0, 255, 255, 0.1)',
-  stroke: 'rgba(0, 255, 255, 0.8)',
+  stroke: 'rgba(0, 255, 255, 1)',
   label: 'Inference',
 }
 
@@ -37,3 +31,38 @@ export const confidenceColorScale: ColorStop[] = [
   { value: 0.5, color: '#cfecb0', label: '50' },
   { value: 0.58, color: '#33a02c', label: '58' },
 ]
+
+function hexToRgb(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ]
+}
+
+export function getColorForValue(colorScale: ColorStop[], value: number, alpha = 1): string {
+  const first = colorScale[0]
+  const last = colorScale[colorScale.length - 1]
+  let hex: string
+  if (value <= first.value) {
+    hex = first.color
+  } else if (value >= last.value) {
+    hex = last.color
+  } else {
+    hex = last.color
+    for (let i = 0; i < colorScale.length - 1; i++) {
+      if (value <= colorScale[i + 1].value) {
+        const t = (value - colorScale[i].value) / (colorScale[i + 1].value - colorScale[i].value)
+        const [r1, g1, b1] = hexToRgb(colorScale[i].color)
+        const [r2, g2, b2] = hexToRgb(colorScale[i + 1].color)
+        const r = Math.round(r1 + (r2 - r1) * t)
+        const g = Math.round(g1 + (g2 - g1) * t)
+        const b = Math.round(b1 + (b2 - b1) * t)
+        hex = `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+        break
+      }
+    }
+  }
+  const [r, g, b] = hexToRgb(hex)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -42,9 +42,6 @@
   padding: 0.5rem 1rem;
   overflow-y: auto;
 }
-.sidebar.global .content .settings {
-  overflow: hidden;
-}
 
 .sidebar .v-card-title {
   background-color: rgba(0, 136, 136, 0.2);


### PR DESCRIPTION
- Use new PMTiles files (2024 still missing on Source)
- Show PMTiles layer depending on the year selected
- Apply threshold to hide fields below threshold
- Style fields according to confidence (currently selected: median)
- Update legend accordingly.
- Make global predictions sidebar scroll if space is insufficient