### PR TITLE
Enable properties box for PMTiles of global data

### DIFF
--- a/src/components/MapComponent.vue
+++ b/src/components/MapComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { Map, View } from 'ol'
 import DataCabinet from './DataCabinet.vue'
 import GlobalFeedbackWidget from './GlobalFeedbackWidget.vue'
@@ -20,6 +20,7 @@ const {
   propertiesBoxPosition,
   originalClickPosition,
   hidePropertiesBox,
+  handleMapClick,
   geoJsonResults,
   initCloudlessLayer,
   updateLayers,
@@ -88,8 +89,15 @@ onMounted(async () => {
     updateLayers()
 
     addMapClickHandler(map.value as Map, areaValues.value)
+    map.value.on('singleclick', handleMapClick)
     // Setup permalink functionality
     setupPermalink(map)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (map.value) {
+    map.value.un('singleclick', handleMapClick)
   }
 })
 

--- a/src/components/ProcessingResults.vue
+++ b/src/components/ProcessingResults.vue
@@ -93,7 +93,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, onBeforeUnmount, computed } from 'vue'
+import { ref, computed } from 'vue'
 import useMap from '../composables/useMap'
 import useNotifier from '../composables/useNotifier'
 import useAreaOfInterest from '../composables/useAreaOfInterest'
@@ -109,7 +109,7 @@ const emit = defineEmits<{
   (e: 'clearResults'): void
 }>()
 
-const { map, handleMapClick, vectorLayer, selectedFeature, hidePropertiesBox } = useMap()
+const { map, vectorLayer, selectedFeature, hidePropertiesBox } = useMap()
 const { clearResults, returnToResults, fitToExtent } = useAreaOfInterest()
 const { showInfo, showError } = useNotifier()
 
@@ -260,24 +260,6 @@ const fitMapToResult = (result: Feature) => {
 
   fitToExtent(map.value!, extent, null)
 }
-
-onMounted(() => {
-  // Add map click handler to detect feature clicks and show properties
-  if (map.value) {
-    map.value.on('singleclick', handleMapClick)
-  }
-})
-
-onBeforeUnmount(() => {
-  selectedFeature.value = null
-})
-
-// Clean up map click handler when component is unmounted
-onUnmounted(() => {
-  if (map.value) {
-    map.value.un('singleclick', handleMapClick)
-  }
-})
 
 const clearResultsHandler = () => {
   // Clear results and zoom back to S2 grid

--- a/src/composables/useMap.ts
+++ b/src/composables/useMap.ts
@@ -49,6 +49,15 @@ watch(selectedFeature, () => vectorLayer.value?.changed())
 const propertiesBoxPosition = ref<{ x: number; y: number } | null>(null)
 const originalClickPosition = ref<{ x: number; y: number } | null>(null)
 const showPropertiesBox = ref(false)
+const selectedFeatureLayer = shallowRef<'vector' | 'global-predictions' | null>(null)
+
+const hidePropertiesBox = () => {
+  showPropertiesBox.value = false
+  selectedFeature.value = null
+  selectedFeatureLayer.value = null
+  propertiesBoxPosition.value = null
+  originalClickPosition.value = null
+}
 
 const geoJsonResults = shallowRef<any[]>([])
 
@@ -161,6 +170,9 @@ const updateLayers = () => {
     if (globalPredictionsLayer.value) {
       map.value.removeLayer(globalPredictionsLayer.value)
       globalPredictionsLayer.value = null
+      if (selectedFeatureLayer.value === 'global-predictions') {
+        hidePropertiesBox()
+      }
     }
     if (globalOverviewLayer.value) {
       map.value.removeLayer(globalOverviewLayer.value)
@@ -170,6 +182,21 @@ const updateLayers = () => {
 }
 
 watch(() => settings.value.mode, updateLayers)
+
+// Hide properties box when zooming out below PMTiles minZoom
+const GLOBAL_PREDICTIONS_MIN_ZOOM = 10
+function handleMoveEnd() {
+  if (selectedFeatureLayer.value === 'global-predictions') {
+    const zoom = map.value?.getView().getZoom()
+    if (zoom !== undefined && zoom < GLOBAL_PREDICTIONS_MIN_ZOOM) {
+      hidePropertiesBox()
+    }
+  }
+}
+watch(map, (newMap, oldMap) => {
+  if (oldMap) oldMap.un('moveend', handleMoveEnd)
+  if (newMap) newMap.on('moveend', handleMoveEnd)
+})
 
 const featureStyle = new Style({
   fill: new Fill({
@@ -198,33 +225,38 @@ export default function useMap() {
     // Check if click is on a feature from our vector layer
     const pixel = event.pixel
 
-    // Check if we clicked on a feature from our results layer
-    const [clickedFeature] = map.value!.getFeaturesAtPixel(pixel, {
-      layerFilter: (layer) => layer === vectorLayer.value,
-    })
-
-    if (clickedFeature) {
-      // Clicked on a feature from our results layer
-      selectedFeature.value = clickedFeature
-
-      // Store original click position for arrow indicator
-      originalClickPosition.value = { x: pixel[0], y: pixel[1] }
-
-      // Calculate optimal position for the properties box to avoid screen edges
-      const optimalPosition = calculateOptimalPosition(pixel[0], pixel[1])
-      propertiesBoxPosition.value = optimalPosition
-      showPropertiesBox.value = true
-    } else {
-      // Clicked outside our results layer features, hide properties box
-      hidePropertiesBox()
+    // Check vectorLayer first (processing results take priority)
+    if (vectorLayer.value) {
+      const [clickedFeature] = map.value!.getFeaturesAtPixel(pixel, {
+        layerFilter: (layer) => layer === vectorLayer.value,
+      })
+      if (clickedFeature) {
+        selectedFeature.value = clickedFeature
+        selectedFeatureLayer.value = 'vector'
+        originalClickPosition.value = { x: pixel[0], y: pixel[1] }
+        propertiesBoxPosition.value = calculateOptimalPosition(pixel[0], pixel[1])
+        showPropertiesBox.value = true
+        return
+      }
     }
-  }
 
-  const hidePropertiesBox = () => {
-    showPropertiesBox.value = false
-    selectedFeature.value = null
-    propertiesBoxPosition.value = null
-    originalClickPosition.value = null
+    // Check globalPredictionsLayer (PMTiles field boundaries)
+    if (globalPredictionsLayer.value) {
+      const [clickedFeature] = map.value!.getFeaturesAtPixel(pixel, {
+        layerFilter: (layer) => layer === globalPredictionsLayer.value,
+      })
+      if (clickedFeature) {
+        selectedFeature.value = clickedFeature
+        selectedFeatureLayer.value = 'global-predictions'
+        originalClickPosition.value = { x: pixel[0], y: pixel[1] }
+        propertiesBoxPosition.value = calculateOptimalPosition(pixel[0], pixel[1])
+        showPropertiesBox.value = true
+        return
+      }
+    }
+
+    // Clicked outside all relevant features
+    hidePropertiesBox()
   }
 
   const calculateOptimalPosition = (clickX: number, clickY: number) => {


### PR DESCRIPTION
I'm not sure whether we want this, but we could also enable the same properties box as in inference mode.

We may want to filter / fine-tune the properties shown.

Was considering showing year and confidence metrics, hide other properties.

We could potentially try to compute area and perimeter on the fly, because they are lacking here but are part of the inference result properties.