### PR TITLE
Added checkbox to show/hide boundaries when zoomed in past render threshold

### DIFF
--- a/src/components/GlobalDataPanel.vue
+++ b/src/components/GlobalDataPanel.vue
@@ -27,9 +27,7 @@ onMounted(() => {
 onUnmounted(() => {
   map.value?.getView()?.un('change:resolution', onZoomChange)
 })
-const fieldBoundariesDisabled = computed(
-  () => zoom.value < GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL,
-)
+const fieldBoundariesDisabled = computed(() => zoom.value < GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL)
 
 const handleLocationSelected = (place: PlaceResult) => {
   if (!map.value) return

--- a/src/components/GlobalDataPanel.vue
+++ b/src/components/GlobalDataPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import useSettings from '../composables/useSettings'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import useSettings, { GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL } from '../composables/useSettings'
 import useMap from '../composables/useMap'
 import useAreaOfInterest from '../composables/useAreaOfInterest'
 import type { PlaceResult } from '../composables/useAreaOfInterest'
@@ -12,6 +13,23 @@ const { settings } = useSettings()
 const { map } = useMap()
 const { fitToExtent } = useAreaOfInterest()
 const { showError } = useNotifier()
+
+const zoom = ref(0)
+const onZoomChange = () => {
+  zoom.value = map.value?.getView()?.getZoom() ?? 0
+}
+onMounted(() => {
+  if (map.value) {
+    onZoomChange()
+    map.value.getView().on('change:resolution', onZoomChange)
+  }
+})
+onUnmounted(() => {
+  map.value?.getView()?.un('change:resolution', onZoomChange)
+})
+const fieldBoundariesDisabled = computed(
+  () => zoom.value < GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL,
+)
 
 const handleLocationSelected = (place: PlaceResult) => {
   if (!map.value) return
@@ -51,6 +69,15 @@ const handleLocationSelected = (place: PlaceResult) => {
           track-color="grey-darken-2"
           thumb-color="teal"
           hide-details
+        />
+        <v-checkbox
+          v-model="settings.showFieldBoundaries"
+          label="Show field boundaries"
+          density="compact"
+          hide-details
+          color="teal"
+          class="mt-2"
+          :disabled="fieldBoundariesDisabled"
         />
         <h3 class="group legend">Legend</h3>
         <MapLegend />

--- a/src/components/GlobalDataPanel.vue
+++ b/src/components/GlobalDataPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import useSettings, { GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL } from '../composables/useSettings'
 import useMap from '../composables/useMap'
 import useAreaOfInterest from '../composables/useAreaOfInterest'
@@ -18,12 +18,25 @@ const zoom = ref(0)
 const onZoomChange = () => {
   zoom.value = map.value?.getView()?.getZoom() ?? 0
 }
-onMounted(() => {
-  if (map.value) {
-    onZoomChange()
-    map.value.getView().on('change:resolution', onZoomChange)
-  }
-})
+
+// Watch map and attach zoom listener when map becomes available
+watch(
+  map,
+  (newMap, oldMap) => {
+    // Clean up previous listener
+    if (oldMap) {
+      oldMap.getView()?.un('change:resolution', onZoomChange)
+    }
+
+    // Attach new listener if map is available
+    if (newMap) {
+      onZoomChange()
+      newMap.getView().on('change:resolution', onZoomChange)
+    }
+  },
+  { immediate: true },
+)
+
 onUnmounted(() => {
   map.value?.getView()?.un('change:resolution', onZoomChange)
 })

--- a/src/composables/useMap.ts
+++ b/src/composables/useMap.ts
@@ -107,8 +107,16 @@ watch(
       }
 
       globalPredictionsLayer.value = createGlobalPredictionsLayer(settings.value)
+      globalPredictionsLayer.value.setVisible(settings.value.showFieldBoundaries)
       map.value.addLayer(globalPredictionsLayer.value)
     }
+  },
+)
+
+watch(
+  () => settings.value.showFieldBoundaries,
+  (visible) => {
+    globalPredictionsLayer.value?.setVisible(visible)
   },
 )
 
@@ -170,6 +178,7 @@ const updateLayers = () => {
     if (!globalPredictionsLayer.value) {
       // Only handle first initialization here, year changes are handled by a watcher on year above
       globalPredictionsLayer.value = createGlobalPredictionsLayer(settings.value)
+      globalPredictionsLayer.value.setVisible(settings.value.showFieldBoundaries)
       map.value.addLayer(globalPredictionsLayer.value)
     }
     if (!globalOverviewLayer.value) {

--- a/src/composables/usePermalink.ts
+++ b/src/composables/usePermalink.ts
@@ -30,6 +30,7 @@ export interface PermalinkStateInference extends PermalinkState {
 
 export interface PermalinkStateGlobal extends PermalinkState {
   threshold: number
+  showFieldBoundaries: boolean
 }
 
 export default function usePermalink() {
@@ -58,6 +59,7 @@ export default function usePermalink() {
     center: [0, 0],
     year: 2025,
     threshold: 0.4,
+    showFieldBoundaries: true,
   }
 
   const getDefaultState = (mode: string): PermalinkStateInference | PermalinkStateGlobal => {
@@ -173,6 +175,7 @@ export default function usePermalink() {
             zoom,
             center,
             threshold: defaultGlobalState.threshold,
+            showFieldBoundaries: defaultGlobalState.showFieldBoundaries,
           }
 
           for (const part of keyValueParts) {
@@ -182,6 +185,8 @@ export default function usePermalink() {
             } else if (part.startsWith('year:')) {
               const year = parseInt(part.substring(5), 10)
               if (!isNaN(year)) result.year = year
+            } else if (part.startsWith('field_boundaries:')) {
+              result.showFieldBoundaries = part.substring(17) === '1'
             }
           }
 
@@ -284,6 +289,7 @@ export default function usePermalink() {
       if (settings.value.year) {
         hashParts.push(`year:${settings.value.year}`)
       }
+      hashParts.push(`field_boundaries:${settings.value.showFieldBoundaries ? 1 : 0}`)
 
       state = {
         mode,
@@ -291,6 +297,7 @@ export default function usePermalink() {
         center,
         threshold: settings.value.threshold,
         year: settings.value.year,
+        showFieldBoundaries: settings.value.showFieldBoundaries,
       }
     }
 
@@ -327,6 +334,7 @@ export default function usePermalink() {
 
   function restoreGlobalState(state: PermalinkStateGlobal) {
     settings.value.threshold = state.threshold
+    settings.value.showFieldBoundaries = state.showFieldBoundaries
     if (state.year) {
       settings.value.year = state.year
     }
@@ -358,6 +366,7 @@ export default function usePermalink() {
         settings.value.areaCoverage,
         settings.value.buffer,
         settings.value.threshold,
+        settings.value.showFieldBoundaries,
       ],
       () => {
         if (!map.value) {

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -12,6 +12,7 @@ export interface Settings {
   expertMode: boolean
   mode: string
   threshold: number
+  showFieldBoundaries: boolean
 }
 
 export interface ModelInfo {
@@ -57,6 +58,7 @@ const defaultSettings: Settings = {
   expertMode: false,
   mode: defaultMode,
   threshold: 0.4,
+  showFieldBoundaries: true,
 }
 
 const defaultModel = computed(() => {


### PR DESCRIPTION
Adds a checkbox that allows me to toggle the fields on off -- helpful when I want to see the underlying imagery. Checkbox is disabled until you zoom past `GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL `

<img width="855" height="811" alt="image" src="https://github.com/user-attachments/assets/c4bdb4c4-2fd6-407d-82ec-3436be2e5239" />
