### PR TITLE
Add additional questions and other improvements to the feedback flow

### DIFF
--- a/src/components/GlobalContributeModal.vue
+++ b/src/components/GlobalContributeModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, ref, watch } from 'vue'
 import type { ContributeForm, ContributionType } from '../composables/useGlobalContribute'
 import PersonalDetailsFields from './PersonalDetailsFields.vue'
 
@@ -16,8 +17,28 @@ interface Emits {
   submit: []
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+
+const submitted = ref(false)
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) submitted.value = false
+  },
+)
+
+const contributionTypesError = computed(() =>
+  submitted.value && props.contributeForm.contributionTypes.length === 0
+    ? 'Please select at least one option.'
+    : undefined,
+)
+
+function onSubmit() {
+  submitted.value = true
+  emit('submit')
+}
 
 const toggleContributionType = (type: ContributionType, form: ContributeForm) => {
   const index = form.contributionTypes.indexOf(type)
@@ -59,6 +80,9 @@ const toggleContributionType = (type: ContributionType, form: ContributeForm) =>
               hide-details
             ></v-checkbox>
           </div>
+          <p v-if="contributionTypesError" class="text-error text-caption mt-2 mb-0">
+            {{ contributionTypesError }}
+          </p>
         </div>
 
         <v-textarea
@@ -89,6 +113,7 @@ const toggleContributionType = (type: ContributionType, form: ContributeForm) =>
           :email="contributeForm.email"
           :organization="contributeForm.organization"
           required
+          :submitted="submitted"
           density="compact"
           field-spacing="mb-2"
           @update:name="emit('update:form', 'name', $event)"
@@ -100,13 +125,7 @@ const toggleContributionType = (type: ContributionType, form: ContributeForm) =>
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn variant="text" @click="emit('update:modelValue', false)">Cancel</v-btn>
-        <v-btn
-          color="teal"
-          variant="flat"
-          :disabled="!canSubmit"
-          :loading="isSubmitting"
-          @click="emit('submit')"
-        >
+        <v-btn color="teal" variant="flat" :loading="isSubmitting" @click="onSubmit">
           Submit
         </v-btn>
       </v-card-actions>

--- a/src/components/GlobalFeedbackDetailsModal.vue
+++ b/src/components/GlobalFeedbackDetailsModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, ref, watch } from 'vue'
 import type { DetailedFeedbackForm } from '../composables/useGlobalFeedback'
 import PersonalDetailsFields from './PersonalDetailsFields.vue'
 
@@ -15,8 +16,32 @@ interface Emits {
   submit: []
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+
+const submitted = ref(false)
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) submitted.value = false
+  },
+)
+
+const qualityFeedbackError = computed(() =>
+  submitted.value && !props.detailsForm.qualityFeedback.trim()
+    ? 'This field is required.'
+    : undefined,
+)
+
+const useCaseError = computed(() =>
+  submitted.value && !props.detailsForm.useCase.trim() ? 'This field is required.' : undefined,
+)
+
+function onSubmit() {
+  submitted.value = true
+  emit('submit')
+}
 </script>
 
 <template>
@@ -35,31 +60,32 @@ const emit = defineEmits<Emits>()
         <v-textarea
           :model-value="detailsForm.qualityFeedback"
           @update:model-value="emit('update:form', 'qualityFeedback', $event)"
-          label="How can we improve field boundaries?"
+          label="How can we improve field boundaries? *"
           hint="Share what's good/bad and what would make them more useful to you"
           variant="outlined"
           rows="4"
           auto-grow
-          required
           class="mb-3"
+          :error-messages="qualityFeedbackError"
         ></v-textarea>
 
         <v-textarea
           :model-value="detailsForm.useCase"
           @update:model-value="emit('update:form', 'useCase', $event)"
-          label="How would you like to use field boundaries?"
+          label="How would you like to use field boundaries? *"
           hint="Describe your specific use case and how field boundaries could be more useful to you"
           variant="outlined"
           rows="3"
           auto-grow
-          required
           class="mb-3"
+          :error-messages="useCaseError"
         ></v-textarea>
 
         <PersonalDetailsFields
           :name="detailsForm.name"
           :email="detailsForm.email"
           :organization="detailsForm.organization"
+          :submitted="submitted"
           @update:name="emit('update:form', 'name', $event)"
           @update:email="emit('update:form', 'email', $event)"
           @update:organization="emit('update:form', 'organization', $event)"
@@ -69,13 +95,7 @@ const emit = defineEmits<Emits>()
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn variant="text" @click="emit('update:modelValue', false)">Cancel</v-btn>
-        <v-btn
-          color="teal"
-          variant="flat"
-          :disabled="!canSubmit"
-          :loading="isSubmitting"
-          @click="emit('submit')"
-        >
+        <v-btn color="teal" variant="flat" :loading="isSubmitting" @click="onSubmit">
           Submit
         </v-btn>
       </v-card-actions>

--- a/src/components/GlobalFeedbackTagsModal.vue
+++ b/src/components/GlobalFeedbackTagsModal.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import type { FeedbackRating, RatingTag, TagOption } from '../composables/useGlobalFeedback'
+import { RATING_TAGS } from '../composables/useGlobalFeedback'
+import { computed, ref, watch } from 'vue'
+
+interface Props {
+  modelValue: boolean
+  selectedLevel: FeedbackRating | null
+  selectedTags: RatingTag[]
+  isSubmitting: boolean
+}
+
+interface Emits {
+  'update:modelValue': [value: boolean]
+  'update:selectedTags': [tags: RatingTag[]]
+  submit: []
+  tellUsMore: []
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const submitted = ref(false)
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) submitted.value = false
+  },
+)
+
+const availableTags = computed<TagOption[]>(() => {
+  if (!props.selectedLevel) return []
+  return RATING_TAGS[props.selectedLevel]
+})
+
+const ratingLabel = computed(() => {
+  if (props.selectedLevel === 3) return 'Good'
+  if (props.selectedLevel === 2) return 'Acceptable'
+  if (props.selectedLevel === 1) return 'Poor'
+  return ''
+})
+
+const canSubmit = computed(() => props.selectedTags.length > 0)
+
+const pendingAction = ref<'submit' | 'tellUsMore' | null>(null)
+
+watch(
+  () => props.isSubmitting,
+  (val) => {
+    if (!val) pendingAction.value = null
+  },
+)
+
+function onTellUsMore() {
+  submitted.value = true
+  pendingAction.value = 'tellUsMore'
+  emit('tellUsMore')
+}
+
+function onSubmit() {
+  submitted.value = true
+  pendingAction.value = 'submit'
+  emit('submit')
+}
+
+function toggleTag(tag: RatingTag) {
+  const current = [...props.selectedTags]
+  const idx = current.indexOf(tag)
+  if (idx >= 0) {
+    current.splice(idx, 1)
+  } else {
+    current.push(tag)
+  }
+  emit('update:selectedTags', current)
+}
+</script>
+
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    @update:model-value="emit('update:modelValue', $event)"
+    max-width="450"
+  >
+    <v-card>
+      <v-card-title class="text-h5">What did you notice?</v-card-title>
+      <v-card-subtitle class="text-body2 px-6 pb-2 text-wrap">
+        You rated this area as <strong>{{ ratingLabel }}</strong
+        >. What best describes what you observed?
+      </v-card-subtitle>
+
+      <v-card-text>
+        <p v-if="submitted && !canSubmit" class="text-error text-caption mb-3 mt-0">
+          Please select at least one option.
+        </p>
+        <v-checkbox
+          v-for="tag in availableTags"
+          :key="tag.value"
+          :model-value="selectedTags.includes(tag.value)"
+          :label="tag.label"
+          color="teal"
+          density="compact"
+          hide-details
+          @update:model-value="toggleTag(tag.value)"
+        />
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn variant="text" @click="emit('update:modelValue', false)">Cancel</v-btn>
+        <v-btn
+          color="teal"
+          variant="flat"
+          :loading="isSubmitting && pendingAction === 'tellUsMore'"
+          @click="onTellUsMore"
+        >
+          Tell Us More
+        </v-btn>
+        <v-btn
+          color="teal"
+          variant="flat"
+          :loading="isSubmitting && pendingAction === 'submit'"
+          @click="onSubmit"
+        >
+          Submit
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/src/components/GlobalFeedbackWidget.vue
+++ b/src/components/GlobalFeedbackWidget.vue
@@ -208,10 +208,6 @@ const sliderLabels = computed(() => {
   justify-content: center;
 }
 
-.feedback-actions--center {
-  justify-content: center;
-}
-
 .zoom-message {
   font-size: 0.8rem;
   text-align: center;

--- a/src/components/GlobalFeedbackWidget.vue
+++ b/src/components/GlobalFeedbackWidget.vue
@@ -5,6 +5,7 @@ import { geoJsonResults } from '../composables/useMap'
 import useSettings from '../composables/useSettings'
 import GlobalContributeModal from './GlobalContributeModal.vue'
 import GlobalFeedbackDetailsModal from './GlobalFeedbackDetailsModal.vue'
+import GlobalFeedbackTagsModal from './GlobalFeedbackTagsModal.vue'
 import useGlobalFeedback from '../composables/useGlobalFeedback'
 import useGlobalContribute from '../composables/useGlobalContribute'
 
@@ -18,13 +19,16 @@ const {
   selectedLevel,
   detailsDialogOpen,
   detailsForm,
+  tagsDialogOpen,
+  selectedTags,
   canProvideFeedback,
-  zoomGateMessage,
+  isMediumZoom,
   canSubmitDetailed,
   isSubmittingQuick,
   isSubmittingDetails,
-  openDetailsDialog,
+  openDetailsDialogFromTags,
   submitQuickFeedback,
+  submitRatingWithTags,
   submitDetailedFeedback,
 } = useGlobalFeedback(map)
 
@@ -78,15 +82,6 @@ const sliderLabels = computed(() => {
               Contribute
             </v-btn>
             <v-btn
-              variant="outlined"
-              color="teal"
-              size="small"
-              :disabled="!selectedLevel"
-              @click="openDetailsDialog"
-            >
-              Tell Us More
-            </v-btn>
-            <v-btn
               variant="flat"
               color="teal"
               size="small"
@@ -100,7 +95,17 @@ const sliderLabels = computed(() => {
         </template>
 
         <template v-else>
-          <div class="zoom-message">{{ zoomGateMessage }}</div>
+          <div class="zoom-message">
+            <template v-if="isMediumZoom">
+              Zoom in more to see <strong>all</strong> fields and to give feedback.
+            </template>
+            <template v-else> Zoom in to see fields and to give feedback. </template>
+          </div>
+          <div class="feedback-actions feedback-actions--center mt-3">
+            <v-btn variant="outlined" color="teal" size="small" @click="openContributeDialog">
+              Contribute
+            </v-btn>
+          </div>
         </template>
       </v-card-text>
     </v-card>
@@ -112,6 +117,16 @@ const sliderLabels = computed(() => {
       :is-submitting="isSubmittingDetails"
       @update:form="(field, value) => (detailsForm[field] = value)"
       @submit="submitDetailedFeedback"
+    />
+
+    <GlobalFeedbackTagsModal
+      v-model="tagsDialogOpen"
+      :selected-level="selectedLevel"
+      :selected-tags="selectedTags"
+      :is-submitting="isSubmittingQuick"
+      @update:selected-tags="selectedTags = $event"
+      @submit="submitRatingWithTags"
+      @tell-us-more="openDetailsDialogFromTags"
     />
 
     <GlobalContributeModal
@@ -184,9 +199,17 @@ const sliderLabels = computed(() => {
 
 .feedback-actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 0.35rem;
   margin-top: 1.2rem;
+}
+
+.feedback-actions--center {
+  justify-content: center;
+}
+
+.feedback-actions--center {
+  justify-content: center;
 }
 
 .zoom-message {

--- a/src/components/PersonalDetailsFields.vue
+++ b/src/components/PersonalDetailsFields.vue
@@ -38,7 +38,7 @@ const emailError = computed(() => {
   if (props.required && props.submitted && !props.email.trim()) {
     return 'This field is required.'
   }
-  if (props.email && !isValidEmail(props.email)) {
+  if (props.submitted && props.email && !isValidEmail(props.email)) {
     return 'Please enter a valid email address.'
   }
   return undefined

--- a/src/components/PersonalDetailsFields.vue
+++ b/src/components/PersonalDetailsFields.vue
@@ -7,12 +7,14 @@ interface Props {
   email: string
   organization: string
   required?: boolean
+  submitted?: boolean
   density?: 'default' | 'comfortable' | 'compact'
   fieldSpacing?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   required: false,
+  submitted: false,
   density: 'default',
   fieldSpacing: 'mb-3',
 })
@@ -25,9 +27,22 @@ interface Emits {
 
 const emit = defineEmits<Emits>()
 
-const emailError = computed(() =>
-  props.email && !isValidEmail(props.email) ? 'Please enter a valid email address.' : undefined,
-)
+const nameError = computed(() => {
+  if (props.required && props.submitted && !props.name.trim()) {
+    return 'This field is required.'
+  }
+  return undefined
+})
+
+const emailError = computed(() => {
+  if (props.required && props.submitted && !props.email.trim()) {
+    return 'This field is required.'
+  }
+  if (props.email && !isValidEmail(props.email)) {
+    return 'Please enter a valid email address.'
+  }
+  return undefined
+})
 </script>
 
 <template>
@@ -38,6 +53,7 @@ const emailError = computed(() =>
     variant="outlined"
     :density="density"
     :class="fieldSpacing"
+    :error-messages="nameError"
   ></v-text-field>
 
   <v-text-field

--- a/src/composables/useGlobalContribute.ts
+++ b/src/composables/useGlobalContribute.ts
@@ -138,13 +138,11 @@ export default function useGlobalContribute() {
 
   const submitContribute = async () => {
     if (!canSubmit.value) {
-      showError('Please fill in all required fields.')
       return
     }
 
     const validationError = validateFormData(contributeForm.value)
     if (validationError) {
-      showError(validationError)
       return
     }
 

--- a/src/composables/useGlobalContribute.ts
+++ b/src/composables/useGlobalContribute.ts
@@ -143,6 +143,7 @@ export default function useGlobalContribute() {
 
     const validationError = validateFormData(contributeForm.value)
     if (validationError) {
+      showError(validationError)
       return
     }
 

--- a/src/composables/useGlobalFeedback.ts
+++ b/src/composables/useGlobalFeedback.ts
@@ -18,6 +18,22 @@ import {
 
 export type FeedbackRating = 1 | 2 | 3
 
+export type RatingTag =
+  | 'clean_boundaries'
+  | 'good_shapes'
+  | 'better_than_expected'
+  | 'over_merged'
+  | 'fragmented'
+  | 'missing_fields'
+  | 'false_positives'
+  | 'jagged_boundaries'
+  | 'tiling_artifacts'
+
+export interface TagOption {
+  value: RatingTag
+  label: string
+}
+
 interface FeedbackOption {
   rating: FeedbackRating
   title: string
@@ -30,6 +46,27 @@ export interface DetailedFeedbackForm {
   name: string
   email: string
   organization: string
+}
+
+const GOOD_TAGS: TagOption[] = [
+  { value: 'clean_boundaries', label: 'Boundary lines are clean and precise' },
+  { value: 'good_shapes', label: 'Field shapes are accurate' },
+  { value: 'better_than_expected', label: 'Quality exceeded expectations' },
+]
+
+const POOR_ACCEPTABLE_TAGS: TagOption[] = [
+  { value: 'over_merged', label: 'Fields are incorrectly merged together' },
+  { value: 'fragmented', label: 'Fields are incorrectly split into pieces' },
+  { value: 'missing_fields', label: 'Real fields are absent from the output' },
+  { value: 'false_positives', label: 'Boundaries appear in areas with no fields' },
+  { value: 'jagged_boundaries', label: 'Boundary lines are noisy or jagged' },
+  { value: 'tiling_artifacts', label: 'Visible seams or discontinuities from tiling' },
+]
+
+export const RATING_TAGS: Record<FeedbackRating, TagOption[]> = {
+  1: POOR_ACCEPTABLE_TAGS,
+  2: POOR_ACCEPTABLE_TAGS,
+  3: GOOD_TAGS,
 }
 
 const FEEDBACK_OPTIONS: FeedbackOption[] = [
@@ -79,7 +116,7 @@ function getViewState(view: View) {
 function getEndpoints() {
   const baseUrl = import.meta.env.VITE_API_BASE_URL || ''
   return {
-    tileRating: `${baseUrl}feedback/tile-rating`,
+    tileRating: `${baseUrl}feedback/rating`,
     tellUsMore: `${baseUrl}feedback/tell-us-more`,
   }
 }
@@ -90,6 +127,8 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
 
   const sliderValue = ref<number>(1)
   const detailsDialogOpen = ref(false)
+  const tagsDialogOpen = ref(false)
+  const selectedTags = ref<RatingTag[]>([])
   const isSubmittingQuick = ref(false)
   const isSubmittingDetails = ref(false)
   const mapZoom = ref<number>(0)
@@ -126,12 +165,19 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     return mapZoom.value >= GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL
   })
 
+  const isMediumZoom = computed(() => {
+    return (
+      mapZoom.value >= GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL &&
+      mapZoom.value < GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL
+    )
+  })
+
   const zoomGateMessage = computed(() => {
     if (mapZoom.value < GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL) {
-      return 'Zoom in to see the fields and to be able to give feedback.'
+      return 'Zoom in to see fields and to give feedback.'
     }
     if (mapZoom.value < GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL) {
-      return 'Zoom in more to show all fields and to be able to give feedback.'
+      return 'Zoom in more to see all fields and to give feedback.'
     }
     return ''
   })
@@ -200,19 +246,59 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       return
     }
 
+    selectedTags.value = []
+    tagsDialogOpen.value = true
+  }
+
+  const closeTagsDialog = () => {
+    tagsDialogOpen.value = false
+  }
+
+  const postRating = async (): Promise<boolean> => {
+    if (!canProvideFeedback.value) {
+      showError(zoomGateMessage.value)
+      return false
+    }
+
+    if (!selectedLevel.value || !mapExtent.value) {
+      showError('Unable to submit feedback. Please try again.')
+      return false
+    }
+
+    if (selectedTags.value.length === 0) {
+      return false
+    }
+
     isSubmittingQuick.value = true
     try {
-      const payload = {
+      await postToEndpoint(tileRatingEndpoint, {
         rating: selectedLevel.value,
         bbox: mapExtent.value,
         resolution: mapResolution.value,
-      }
-      await postToEndpoint(tileRatingEndpoint, payload)
-      showSuccess('Thanks for the feedback!')
+        tags: selectedTags.value,
+      })
+      return true
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Failed to submit feedback.')
+      return false
     } finally {
       isSubmittingQuick.value = false
+    }
+  }
+
+  const submitRatingWithTags = async () => {
+    const ok = await postRating()
+    if (ok) {
+      showSuccess('Thanks for the feedback!')
+      closeTagsDialog()
+    }
+  }
+
+  const openDetailsDialogFromTags = async () => {
+    const ok = await postRating()
+    if (ok) {
+      closeTagsDialog()
+      openDetailsDialog()
     }
   }
 
@@ -255,16 +341,14 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       showError(zoomGateMessage.value)
       return
     }
-    if (!selectedLevel.value) {
-      showError('Please select one of the options before submitting.')
-      return
-    }
-    if (!detailsForm.value.qualityFeedback.trim() || !detailsForm.value.useCase.trim()) {
-      showError('Please fill in the required fields before submitting.')
+    if (
+      !selectedLevel.value ||
+      !detailsForm.value.qualityFeedback.trim() ||
+      !detailsForm.value.useCase.trim()
+    ) {
       return
     }
     if (!isValidEmail(detailsForm.value.email)) {
-      showError('Please provide a valid email address.')
       return
     }
     if (!mapExtent.value) {
@@ -299,6 +383,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
 
       closeDetailsDialog()
       resetDetailsForm()
+      selectedTags.value = []
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Failed to submit detailed feedback.')
     } finally {
@@ -312,14 +397,19 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     selectedLevel,
     detailsDialogOpen,
     detailsForm,
+    tagsDialogOpen,
+    selectedTags,
     canProvideFeedback,
+    isMediumZoom,
     zoomGateMessage,
     canSubmitDetailed,
     isSubmittingQuick,
     isSubmittingDetails,
     openDetailsDialog,
     closeDetailsDialog,
+    openDetailsDialogFromTags,
     submitQuickFeedback,
+    submitRatingWithTags,
     submitDetailedFeedback,
   }
 }


### PR DESCRIPTION
- Update requests according to new OpenAPI file
- Add  a modal that is shown after rating submission, allowing users to select qualitative observations via checkboxes (options vary by rating)
- Move "Tell Us More" button from the feedback widget into the tags modal
- Replace disabled submit buttons with always-active buttons; inline validation errors appear after the first submit attempt (fields, checkboxes, and personal details)
- Contribute button is always visible regardless of zoom level
- Contribute button is centered when shown alone; left-aligned when paired with a Submit button
- Zoom gate message renders "all" in bold via template markup instead of a plain computed string, generally making the messages more concise