### PR TITLE
Hotfixes

### DIFF
--- a/src/components/GeocodingSearch.vue
+++ b/src/components/GeocodingSearch.vue
@@ -58,6 +58,8 @@ watch(
 const onLocationSelected = (item: { value: PlaceResult; title: string } | null) => {
   if (item) {
     emit('location-selected', item.value)
+    placeSearch.value = ''
+    suggestedPlaces.value = []
   }
 }
 </script>
@@ -75,6 +77,7 @@ const onLocationSelected = (item: { value: PlaceResult; title: string } | null) 
       hide-details
       dense
       variant="outlined"
+      attach
     ></v-autocomplete>
     <v-menu open-on-hover :close-on-content-click="false" max-width="400">
       <template #activator="{ props }">

--- a/src/components/GeocodingSearch.vue
+++ b/src/components/GeocodingSearch.vue
@@ -2,7 +2,7 @@
 import { ref, shallowRef, watch } from 'vue'
 import { debounce } from 'vuetify/lib/util/helpers.mjs'
 import type { PlaceResult } from '../composables/useAreaOfInterest'
-import { mdiHelpCircleOutline } from '@mdi/js'
+import { mdiInformationOutline } from '@mdi/js'
 
 const emit = defineEmits<{
   (e: 'location-selected', place: PlaceResult): void
@@ -81,7 +81,7 @@ const onLocationSelected = (item: { value: PlaceResult; title: string } | null) 
     ></v-autocomplete>
     <v-menu open-on-hover :close-on-content-click="false" max-width="400">
       <template #activator="{ props }">
-        <v-icon class="ml-1" :icon="mdiHelpCircleOutline" size="x-small" v-bind="props"></v-icon>
+        <v-icon class="ml-1" :icon="mdiInformationOutline" size="x-small" v-bind="props"></v-icon>
       </template>
       <v-sheet class="pa-3 text-body-2">
         Geocoding provided by Nominatim.<br />

--- a/src/components/GeocodingSearch.vue
+++ b/src/components/GeocodingSearch.vue
@@ -71,7 +71,7 @@ const onLocationSelected = (item: { value: PlaceResult; title: string } | null) 
       v-model:search="placeSearch"
       :loading="isLoadingPlaces"
       :items="suggestedPlaces"
-      label="Search for a place"
+      label="Search a place or address…"
       item-title="title"
       return-object
       hide-details

--- a/src/components/GlobalDataPanel.vue
+++ b/src/components/GlobalDataPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { mdiHelpCircleOutline } from '@mdi/js'
+import { mdiInformationOutline } from '@mdi/js'
 import useSettings from '../composables/useSettings'
 import useMap from '../composables/useMap'
 import { getEffectiveCloudlessYear } from '../layers/S2-Cloudless-Layer'
@@ -102,7 +102,7 @@ const handleLocationSelected = (place: PlaceResult) => {
           <h3>Download Data</h3>
           <v-menu open-on-hover :close-on-content-click="false" max-width="400">
             <template #activator="{ props }">
-              <v-icon :icon="mdiHelpCircleOutline" size="x-small" v-bind="props"></v-icon>
+              <v-icon :icon="mdiInformationOutline" size="x-small" v-bind="props"></v-icon>
             </template>
             <v-sheet class="pa-3 text-body-2">
               <p class="pb-2">

--- a/src/components/GlobalDataPanel.vue
+++ b/src/components/GlobalDataPanel.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { mdiHelpCircleOutline } from '@mdi/js'
 import useSettings from '../composables/useSettings'
 import useMap from '../composables/useMap'
+import { getEffectiveCloudlessYear } from '../layers/S2-Cloudless-Layer'
 import useAreaOfInterest from '../composables/useAreaOfInterest'
 import type { PlaceResult } from '../composables/useAreaOfInterest'
 import useNotifier from '../composables/useNotifier'
@@ -12,6 +14,10 @@ import MapLegend from './MapLegend.vue'
 
 const { settings } = useSettings()
 const { map } = useMap()
+
+const basemapYearMismatch = computed(
+  () => settings.value.year !== getEffectiveCloudlessYear(settings.value.year),
+)
 const { fitToExtent } = useAreaOfInterest()
 const { showError } = useNotifier()
 useDownloadGrid()
@@ -60,6 +66,15 @@ const handleLocationSelected = (place: PlaceResult) => {
           <v-radio label="2024" :value="2024"></v-radio>
           <v-radio label="2025" :value="2025"></v-radio>
         </v-radio-group>
+        <v-alert
+          v-if="basemapYearMismatch"
+          type="warning"
+          variant="tonal"
+          density="compact"
+          class="mt-2"
+        >
+          No basemap is available for {{ settings.year }}. Showing the {{ getEffectiveCloudlessYear(settings.year) }} basemap instead.
+        </v-alert>
         <h3 class="group">Confidence Threshold: {{ settings.threshold }}%</h3>
         <v-slider
           v-model.number="settings.threshold"

--- a/src/components/GlobalDataPanel.vue
+++ b/src/components/GlobalDataPanel.vue
@@ -73,7 +73,8 @@ const handleLocationSelected = (place: PlaceResult) => {
           density="compact"
           class="mt-2"
         >
-          No basemap is available for {{ settings.year }}. Showing the {{ getEffectiveCloudlessYear(settings.year) }} basemap instead.
+          No basemap is available for {{ settings.year }}. Showing the
+          {{ getEffectiveCloudlessYear(settings.year) }} basemap instead.
         </v-alert>
         <h3 class="group">Confidence Threshold: {{ settings.threshold }}%</h3>
         <v-slider

--- a/src/components/MapComponent.vue
+++ b/src/components/MapComponent.vue
@@ -49,6 +49,7 @@ onMounted(async () => {
     layers: [createLabelLayer()],
     view: new View({
       maxResolution: createXYZ({ tileSize: 512 }).getResolution(0), // use Mapbox/MapLibre compatible resolutions
+      maxZoom: 16,
       center: [0, 0],
       zoom: 1,
     }),

--- a/src/components/MapComponent.vue
+++ b/src/components/MapComponent.vue
@@ -54,6 +54,19 @@ onMounted(async () => {
     }),
   })
 
+  // Initialize the cloudless base layer
+  initCloudlessLayer()
+
+  // Initialize layers
+  updateLayers()
+
+  addMapClickHandler(map.value as Map, areaValues.value)
+  map.value.on('singleclick', handleMapClick)
+  // Add scale bar
+  map.value.addControl(new ScaleLine())
+  // Setup permalink functionality
+  setupPermalink(map)
+
   // Get area values and models from API
   try {
     const token = generateJWT()
@@ -84,22 +97,6 @@ onMounted(async () => {
     }
   } catch (error: any) {
     critical.value = `Can't connect to server: ${error?.message || error}`
-  }
-
-  // Add layers after map is initialized
-  if (map.value) {
-    // Initialize the cloudless base layer
-    initCloudlessLayer()
-
-    // Initialize layers
-    updateLayers()
-
-    addMapClickHandler(map.value as Map, areaValues.value)
-    map.value.on('singleclick', handleMapClick)
-    // Add scale bar
-    map.value.addControl(new ScaleLine())
-    // Setup permalink functionality
-    setupPermalink(map)
   }
 })
 

--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -682,7 +682,8 @@ defineExpose({ openModelSelection })
           <v-row v-if="basemapYearMismatch">
             <v-col>
               <v-alert type="warning" variant="tonal" density="compact">
-                No basemap is available for {{ settings.year }}. Showing the {{ getEffectiveCloudlessYear(settings.year) }} basemap instead.
+                No basemap is available for {{ settings.year }}. Showing the
+                {{ getEffectiveCloudlessYear(settings.year) }} basemap instead.
               </v-alert>
             </v-col>
           </v-row>

--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -23,6 +23,7 @@ import TilePreview from './TilePreview.vue'
 import GeocodingSearch from './GeocodingSearch.vue'
 import useStacLayer from '../composables/useStacLayer'
 import { debounce } from 'vuetify/lib/util/helpers.mjs'
+import { getEffectiveCloudlessYear } from '../layers/S2-Cloudless-Layer'
 
 const emit = defineEmits<{
   (e: 'workStateChanged', isWorking: boolean): void
@@ -84,6 +85,10 @@ const activePanel = ref<string | null>(currentMgrsTileId.value ? null : 'aoi')
 const hasLoadedMore = ref(false)
 const sceneSelectionStatus = ref<boolean | null>(null)
 const sceneYears = Array.from({ length: 10 }, (_, i) => new Date().getFullYear() - i)
+
+const basemapYearMismatch = computed(
+  () => settings.value.year !== getEffectiveCloudlessYear(settings.value.year),
+)
 
 const isSelectingScenes = computed(
   () => sceneSelectionStatus.value === null && settings.value.autoSceneSelection,
@@ -671,6 +676,14 @@ defineExpose({ openModelSelection })
                 hide-details
                 variant="outlined"
               />
+            </v-col>
+          </v-row>
+
+          <v-row v-if="basemapYearMismatch">
+            <v-col>
+              <v-alert type="warning" variant="tonal" density="compact">
+                No basemap is available for {{ settings.year }}. Showing the {{ getEffectiveCloudlessYear(settings.year) }} basemap instead.
+              </v-alert>
             </v-col>
           </v-row>
 

--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -12,7 +12,7 @@ import useAreaOfInterest from '../composables/useAreaOfInterest'
 import useProcessingMode from '../composables/useProcessingMode'
 import useMap from '../composables/useMap'
 import {
-  mdiHelpCircleOutline,
+  mdiInformationOutline,
   mdiCheckBold,
   mdiExclamationThick,
   mdiClose,
@@ -480,7 +480,7 @@ defineExpose({ openModelSelection })
                   <template #activator="{ props }">
                     <v-icon
                       class="ml-1"
-                      :icon="mdiHelpCircleOutline"
+                      :icon="mdiInformationOutline"
                       size="x-small"
                       v-bind="props"
                     ></v-icon>

--- a/src/components/ProcessingResults.vue
+++ b/src/components/ProcessingResults.vue
@@ -77,7 +77,11 @@
         >
           <v-icon :icon="mdiTarget"></v-icon>
         </v-btn>
-        <v-btn class="action-button download-results" @click="downloadResults" density="comfortable"
+        <v-btn
+          class="action-button download-results"
+          @click="downloadResults"
+          density="comfortable"
+          title="Export all detected fields as GeoJSON."
           >Download</v-btn
         >
         <v-btn
@@ -85,6 +89,7 @@
           @click="clearResultsHandler"
           color="error"
           density="compact"
+          itle="Remove these results from the map."
           >Clear</v-btn
         >
       </div>

--- a/src/components/TilePreview.vue
+++ b/src/components/TilePreview.vue
@@ -102,10 +102,16 @@ const handleViewOnMap = async () => {
     </div>
     <div class="result-details">
       <div>Date: {{ tile.date }}</div>
-      <div v-if="typeof tile.cloudCover === 'number'">
+      <div
+        v-if="typeof tile.cloudCover === 'number'"
+        title="Percent of the scene obscured by clouds."
+      >
         Cloud Cover: {{ tile.cloudCover.toFixed(1) }}%
       </div>
-      <div v-if="typeof tile.areaCoverage === 'number'">
+      <div
+        v-if="typeof tile.areaCoverage === 'number'"
+        title="Percent of the tile area covered by valid data (e.g. not nodata or masked out)."
+      >
         Area Coverage: {{ tile.areaCoverage.toFixed(1) }}%
       </div>
     </div>

--- a/src/composables/useDownloadGrid.ts
+++ b/src/composables/useDownloadGrid.ts
@@ -43,7 +43,7 @@ export function featureToGridCell(feature: FeatureLike): GridCell {
 function triggerDownload(url: string, filename: string) {
   const a = document.createElement('a')
   a.href = url
-  a.download = filename
+  a.download = settings.value.year + '-' + filename
   a.rel = 'noopener'
   document.body.appendChild(a)
   a.click()

--- a/src/composables/useDownloadGrid.ts
+++ b/src/composables/useDownloadGrid.ts
@@ -43,7 +43,9 @@ export function featureToGridCell(feature: FeatureLike): GridCell {
 function triggerDownload(url: string, filename: string) {
   const a = document.createElement('a')
   a.href = url
-  a.download = settings.value.year + '-' + filename
+  // This doesn't actually set the filename as we download from another host,
+  // so browsers block providing a custom name (CORS same-origin policy).
+  a.download = filename
   a.rel = 'noopener'
   document.body.appendChild(a)
   a.click()

--- a/src/composables/useGlobalFeedback.ts
+++ b/src/composables/useGlobalFeedback.ts
@@ -5,7 +5,7 @@ import { toLonLat } from 'ol/proj'
 import { unByKey } from 'ol/Observable'
 import type { EventsKey } from 'ol/events'
 import useNotifier from './useNotifier'
-import {
+import useSettings, {
   GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL,
   GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL,
 } from './useSettings'
@@ -123,6 +123,7 @@ function getEndpoints() {
 
 export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
   const { showError, showSuccess } = useNotifier()
+  const { settings } = useSettings()
   const { tileRating: tileRatingEndpoint, tellUsMore: tellUsMoreEndpoint } = getEndpoints()
 
   const sliderValue = ref<number>(1)
@@ -275,6 +276,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
         rating: selectedLevel.value,
         bbox: mapExtent.value,
         resolution: mapResolution.value,
+        confidence_threshold: settings.value.threshold,
         tags: selectedTags.value,
       })
       return true
@@ -361,6 +363,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
         rating: selectedLevel.value,
         bbox: mapExtent.value,
         resolution: mapResolution.value,
+        confidence_threshold: settings.value.threshold,
         tags: selectedTags.value,
       }
 

--- a/src/composables/useGlobalFeedback.ts
+++ b/src/composables/useGlobalFeedback.ts
@@ -294,12 +294,9 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     }
   }
 
-  const openDetailsDialogFromTags = async () => {
-    const ok = await postRating()
-    if (ok) {
-      closeTagsDialog()
-      openDetailsDialog()
-    }
+  const openDetailsDialogFromTags = () => {
+    closeTagsDialog()
+    openDetailsDialog()
   }
 
   const openDetailsDialog = () => {
@@ -364,6 +361,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
         rating: selectedLevel.value,
         bbox: mapExtent.value,
         resolution: mapResolution.value,
+        tags: selectedTags.value,
       }
 
       if (detailsForm.value.name) {

--- a/src/composables/useMap.ts
+++ b/src/composables/useMap.ts
@@ -11,7 +11,7 @@ import type { Extent } from 'ol/extent'
 import { type FeatureCollection } from 'geojson'
 import useNotifier from './useNotifier'
 import useSettings from './useSettings'
-import createCloudlessLayer from '../layers/S2-Cloudless-Layer'
+import createCloudlessLayer, { getEffectiveCloudlessYear } from '../layers/S2-Cloudless-Layer'
 import createS2GridLayer from '../layers/S2-Grid-Layer'
 import {
   createGlobalPredictionsLayer,
@@ -71,8 +71,13 @@ const cloudlessLayer = shallowRef<TileLayer<XYZ> | null>(null)
 // Watch for year changes and update the cloudless layer
 watch(
   () => settings.value.year,
-  (newYear) => {
+  (newYear, oldYear) => {
     if (!map.value) {
+      return
+    }
+
+    // Skip reload when the effective (clamped) year hasn't changed (e.g. 2024 -> 2025)
+    if (getEffectiveCloudlessYear(newYear) === getEffectiveCloudlessYear(oldYear)) {
       return
     }
 

--- a/src/layers/S2-Cloudless-Layer.ts
+++ b/src/layers/S2-Cloudless-Layer.ts
@@ -1,12 +1,15 @@
 import TileLayer from 'ol/layer/Tile'
 import { XYZ } from 'ol/source'
 
+export const MIN_CLOUDLESS_YEAR = 2016
+export const MAX_CLOUDLESS_YEAR = 2024
+
+export function getEffectiveCloudlessYear(year: number): number {
+  return Math.min(MAX_CLOUDLESS_YEAR, Math.max(MIN_CLOUDLESS_YEAR, year))
+}
+
 export default function createCloudlessLayer(year: number) {
-  if (year < 2016) {
-    year = 2016
-  } else if (year > 2024) {
-    year = 2024
-  }
+  year = getEffectiveCloudlessYear(year)
   return new TileLayer({
     source: new XYZ({
       url: `https://tiles.maps.eox.at/wmts?layer=s2cloudless${year === 2016 ? '' : '-' + year}_3857&style=default&tilematrixset=GoogleMapsCompatible&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}`,

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -62,17 +62,19 @@ function setModeValue(newValue: number) {
 
     <!-- About Dialog -->
     <v-dialog v-model="aboutDialog" width="auto">
-      <v-card
-        max-width="600"
-        border
-        :prepend-icon="mdiInformation"
-        title="About the Fields of The World Explorer"
-      >
+      <v-card max-width="600" title="Welcome to the Fields of The World (FTW) Explorer">
         <v-card-text>
-          Welcome to the Fields of the World (FTW) Explorer Web App. Use it to either explore the
-          global field boundary data or run the FTW model on Sentinel-2 Level 2A Collection 1
-          imagery. Both allow you to visualize predicted field boundaries for your chosen area of
-          interest. To get started, choose your area of interest on the map.
+          <p class="mb-2">This app has two modes, switched at the top of the screen:</p>
+          <ul class="ps-5 mb-0">
+            <li class="mb-2">
+              <strong>Global:</strong> Browse pre-computed global field boundaries for 2024 and
+              2025. Zoom in to explore individual fields, or download a 1° tile as GeoParquet.
+            </li>
+            <li>
+              <strong>Custom:</strong> Run the FTW model on-demand over an area you choose, using
+              Sentinel-2 Level 2A imagery.
+            </li>
+          </ul>
         </v-card-text>
         <v-card-actions>
           <v-checkbox-btn v-model="dontShowAgain" label="Don't show again"></v-checkbox-btn>

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -41,7 +41,7 @@ function setModeValue(newValue: number) {
         @click="aboutDialog = true"
       />
       <v-card variant="outlined" rounded="lg" class="switch">
-        <span class="switch-label">Predictions</span>
+        <span class="switch-label">Mode</span>
         <v-divider vertical></v-divider>
         <v-btn-toggle
           v-model="modeValue"
@@ -117,11 +117,20 @@ function setModeValue(newValue: number) {
 #title .switch-label {
   padding: 0 0.75rem;
   font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+  height: 100%;
+  display: flex;
+  align-items: center;
+  border-right: 1px solid rgba(255, 255, 255, 0.7);
 }
 
 #title .switch :deep(.v-btn) {
   padding: 0 0.75rem;
   min-width: unset;
+}
+
+#title .switch :deep(.bg-primary) {
+  --v-theme-overlay-multiplier: 0;
 }
 
 .map-view {

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import MapComponent from '../components/MapComponent.vue'
-import { mdiInformation } from '@mdi/js'
 import { ref, watch } from 'vue'
 import useSettings from '../composables/useSettings'
 

--- a/src/workers/predictions-worker.ts
+++ b/src/workers/predictions-worker.ts
@@ -37,7 +37,7 @@ layer.setStyle((feature, resolution) => {
   const widthPx = (extent[2] - extent[0]) / resolution
   const heightPx = (extent[3] - extent[1]) / resolution
   if (widthPx < 3 && heightPx < 3) return smallStyle
-  fill.setColor(getColorForValue(confidenceColorScale, confidence, 0.35))
+  fill.setColor(getColorForValue(confidenceColorScale, confidence, 0.5))
   return polyStyle
 })
 


### PR DESCRIPTION
- [x] Limit max zoom to 16
- [x] Opacity 100% isn't actually 100% -> set field background from 0.35 to 0.5
- [x] Basemap shouldn't disappear and reappear when switching between the two
- [x] Add a label to the page to make it clear when the basemap comes from -> see attribution
- [x] Update app to send tags (questions) as part of the tell us more request, don't send a separate rating request in this case
- [x] Record what confidence the user is looking at when submitting (client-side only)
- [x] Menu improvements (see also #266)
- [x] Hotfixes for Geocoding and reactivity in general
- [x] Show warning when basemap year doesn't match data year