### PR TITLE
Fix feedback widget UX issues (#283, #290, #285, #284)

### DIFF
--- a/src/components/GlobalFeedbackWidget.vue
+++ b/src/components/GlobalFeedbackWidget.vue
@@ -16,6 +16,7 @@ const hasInferenceResults = computed(() => geoJsonResults.value.length > 0)
 const {
   options,
   sliderValue,
+  hasInteractedWithSlider,
   selectedLevel,
   detailsDialogOpen,
   detailsForm,
@@ -77,19 +78,23 @@ const sliderLabels = computed(() => {
             </v-slider>
           </div>
 
+          <div v-if="!hasInteractedWithSlider" class="interaction-hint">
+            Drag the slider to confirm your rating
+          </div>
+
           <div class="feedback-actions mt-3">
             <v-btn variant="outlined" color="teal" size="small" @click="openContributeDialog">
               Contribute
             </v-btn>
             <v-btn
               variant="flat"
-              color="teal"
+              :color="selectedLevel && hasInteractedWithSlider ? 'teal' : undefined"
               size="small"
               :loading="isSubmittingQuick"
-              :disabled="!selectedLevel"
+              :disabled="!selectedLevel || !hasInteractedWithSlider"
               @click="submitQuickFeedback"
             >
-              Submit
+              Continue
             </v-btn>
           </div>
         </template>
@@ -180,6 +185,12 @@ const sliderLabels = computed(() => {
 }
 
 .feedback-slider :deep(.v-slider__tick-label) {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.interaction-hint {
+  font-size: 0.75rem;
+  text-align: center;
   color: rgba(255, 255, 255, 0.7);
 }
 

--- a/src/components/GlobalFeedbackWidget.vue
+++ b/src/components/GlobalFeedbackWidget.vue
@@ -3,11 +3,9 @@ import { computed } from 'vue'
 import useMap from '../composables/useMap'
 import { geoJsonResults } from '../composables/useMap'
 import useSettings from '../composables/useSettings'
-import GlobalContributeModal from './GlobalContributeModal.vue'
 import GlobalFeedbackDetailsModal from './GlobalFeedbackDetailsModal.vue'
 import GlobalFeedbackTagsModal from './GlobalFeedbackTagsModal.vue'
 import useGlobalFeedback from '../composables/useGlobalFeedback'
-import useGlobalContribute from '../composables/useGlobalContribute'
 
 const { settings } = useSettings()
 const { map } = useMap()
@@ -16,14 +14,13 @@ const hasInferenceResults = computed(() => geoJsonResults.value.length > 0)
 const {
   options,
   sliderValue,
-  sliderTouched,
   selectedLevel,
   detailsDialogOpen,
   detailsForm,
   tagsDialogOpen,
   selectedTags,
   canProvideFeedback,
-  isMediumZoom,
+  zoomGateMessage,
   canSubmitQuick,
   canSubmitDetailed,
   isSubmittingQuick,
@@ -33,17 +30,6 @@ const {
   submitRatingWithTags,
   submitDetailedFeedback,
 } = useGlobalFeedback(map)
-
-const {
-  CONTRIBUTION_OPTIONS,
-  contributeDialogOpen,
-  contributeForm,
-  canSubmit: canSubmitContribute,
-  isSubmitting: isSubmittingContribute,
-  openContributeDialog,
-  submitContribute,
-  updateFormField,
-} = useGlobalContribute()
 
 const sliderLabels = computed(() => {
   return Object.fromEntries(options.map((opt, i) => [i, opt.title]))
@@ -79,14 +65,7 @@ const sliderLabels = computed(() => {
             </v-slider>
           </div>
 
-          <div v-if="!sliderTouched" class="interaction-hint">
-            Drag the slider to confirm your rating
-          </div>
-
           <div class="feedback-actions mt-3">
-            <v-btn variant="outlined" color="teal" size="small" @click="openContributeDialog">
-              Contribute
-            </v-btn>
             <v-btn
               variant="flat"
               :color="canSubmitQuick ? 'teal' : undefined"
@@ -101,17 +80,7 @@ const sliderLabels = computed(() => {
         </template>
 
         <template v-else>
-          <div class="zoom-message">
-            <template v-if="isMediumZoom">
-              Zoom in more to see <strong>all</strong> fields and to give feedback.
-            </template>
-            <template v-else> Zoom in to see fields and to give feedback. </template>
-          </div>
-          <div class="feedback-actions feedback-actions--center mt-3">
-            <v-btn variant="outlined" color="teal" size="small" @click="openContributeDialog">
-              Contribute
-            </v-btn>
-          </div>
+          <div class="zoom-message">{{ zoomGateMessage }}</div>
         </template>
       </v-card-text>
     </v-card>
@@ -133,16 +102,6 @@ const sliderLabels = computed(() => {
       @update:selected-tags="selectedTags = $event"
       @submit="submitRatingWithTags"
       @tell-us-more="openDetailsDialogFromTags"
-    />
-
-    <GlobalContributeModal
-      v-model="contributeDialogOpen"
-      :contribute-form="contributeForm"
-      :contribution-options="CONTRIBUTION_OPTIONS"
-      :can-submit="canSubmitContribute"
-      :is-submitting="isSubmittingContribute"
-      @update:form="updateFormField"
-      @submit="submitContribute"
     />
   </div>
 </template>
@@ -189,12 +148,6 @@ const sliderLabels = computed(() => {
   color: rgba(255, 255, 255, 0.7);
 }
 
-.interaction-hint {
-  font-size: 0.75rem;
-  text-align: center;
-  color: rgba(255, 255, 255, 0.7);
-}
-
 .feedback-slider :deep(.v-slider-thumb__label) {
   background-color: rgba(0, 136, 136, 1);
   min-width: 220px;
@@ -211,13 +164,9 @@ const sliderLabels = computed(() => {
 
 .feedback-actions {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 0.35rem;
   margin-top: 1.2rem;
-}
-
-.feedback-actions--center {
-  justify-content: center;
 }
 
 .zoom-message {

--- a/src/components/GlobalFeedbackWidget.vue
+++ b/src/components/GlobalFeedbackWidget.vue
@@ -16,7 +16,7 @@ const hasInferenceResults = computed(() => geoJsonResults.value.length > 0)
 const {
   options,
   sliderValue,
-  hasInteractedWithSlider,
+  sliderTouched,
   selectedLevel,
   detailsDialogOpen,
   detailsForm,
@@ -24,6 +24,7 @@ const {
   selectedTags,
   canProvideFeedback,
   isMediumZoom,
+  canSubmitQuick,
   canSubmitDetailed,
   isSubmittingQuick,
   isSubmittingDetails,
@@ -78,7 +79,7 @@ const sliderLabels = computed(() => {
             </v-slider>
           </div>
 
-          <div v-if="!hasInteractedWithSlider" class="interaction-hint">
+          <div v-if="!sliderTouched" class="interaction-hint">
             Drag the slider to confirm your rating
           </div>
 
@@ -88,10 +89,10 @@ const sliderLabels = computed(() => {
             </v-btn>
             <v-btn
               variant="flat"
-              :color="selectedLevel && hasInteractedWithSlider ? 'teal' : undefined"
+              :color="canSubmitQuick ? 'teal' : undefined"
               size="small"
               :loading="isSubmittingQuick"
-              :disabled="!selectedLevel || !hasInteractedWithSlider"
+              :disabled="!canSubmitQuick"
               @click="submitQuickFeedback"
             >
               Continue

--- a/src/components/MapComponent.vue
+++ b/src/components/MapComponent.vue
@@ -4,6 +4,7 @@ import { Map, View } from 'ol'
 import { ScaleLine } from 'ol/control'
 import DataCabinet from './DataCabinet.vue'
 import GlobalFeedbackWidget from './GlobalFeedbackWidget.vue'
+import GlobalContributeModal from './GlobalContributeModal.vue'
 import ProcessingResults from './ProcessingResults.vue'
 import PropertiesDisplay from './PropertiesDisplay.vue'
 import createLabelLayer from '../layers/Label-Layer'
@@ -13,7 +14,9 @@ import usePermalink from '../composables/usePermalink'
 import useMap from '../composables/useMap'
 import useSettings from '../composables/useSettings'
 import useDownloadGrid from '../composables/useDownloadGrid'
+import useGlobalContribute from '../composables/useGlobalContribute'
 import { createXYZ } from 'ol/tilegrid'
+import { mdiHandHeart } from '@mdi/js'
 
 const {
   map,
@@ -33,6 +36,17 @@ const { hoveredGridCell, hoveredGridPosition } = useDownloadGrid()
 
 const { addMapClickHandler } = useAreaOfInterest()
 const { setAvailableModels, settings } = useSettings()
+
+const {
+  CONTRIBUTION_OPTIONS,
+  contributeDialogOpen,
+  contributeForm,
+  canSubmit: canSubmitContribute,
+  isSubmitting: isSubmittingContribute,
+  openContributeDialog,
+  submitContribute,
+  updateFormField,
+} = useGlobalContribute()
 
 function formatDeg(value: number, isLat: boolean): string {
   const abs = Math.abs(value)
@@ -134,6 +148,30 @@ defineExpose({
 
     <GlobalFeedbackWidget v-if="map && settings.mode === 'global'" />
 
+    <v-btn
+      v-if="settings.mode === 'global'"
+      class="contribute-fab"
+      icon
+      color="teal"
+      elevation="8"
+      size="large"
+      @click="openContributeDialog"
+    >
+      <v-icon :icon="mdiHandHeart" size="26"></v-icon>
+      <v-tooltip activator="parent" location="left">Contribute</v-tooltip>
+    </v-btn>
+
+    <GlobalContributeModal
+      v-if="settings.mode === 'global'"
+      v-model="contributeDialogOpen"
+      :contribute-form="contributeForm"
+      :contribution-options="CONTRIBUTION_OPTIONS"
+      :can-submit="canSubmitContribute"
+      :is-submitting="isSubmittingContribute"
+      @update:form="updateFormField"
+      @submit="submitContribute"
+    />
+
     <!-- Download grid hover tooltip -->
     <div
       v-if="hoveredGridCell && hoveredGridPosition && settings.downloads"
@@ -227,6 +265,13 @@ defineExpose({
 </template>
 
 <style scoped>
+.contribute-fab {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1001;
+}
+
 #critical {
   position: absolute;
   bottom: 1rem;

--- a/src/components/PropertiesDisplay.vue
+++ b/src/components/PropertiesDisplay.vue
@@ -11,13 +11,14 @@
     </v-list-item-title>
     <template #append>
       <v-tooltip
-        v-if="preciseAreaValue(key, value)"
         location="top"
-        :text="preciseAreaValue(key, value)"
+        :disabled="!preciseAreaValue(key, value)"
+        :text="preciseAreaValue(key, value) || ''"
       >
         <template #activator="{ props: tooltipProps }">
           <div
             v-bind="tooltipProps"
+            tabindex="0"
             class="text-caption text-white text-right"
             style="max-width: 120px; word-break: break-word"
           >
@@ -25,13 +26,6 @@
           </div>
         </template>
       </v-tooltip>
-      <div
-        v-else
-        class="text-caption text-white text-right"
-        style="max-width: 120px; word-break: break-word"
-      >
-        {{ formattedValue(key, value) }}
-      </div>
     </template>
   </v-list-item>
 </template>
@@ -59,12 +53,8 @@ const squareMetersFormatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 0,
 })
 
-function isDefaultAreaField(key: string | number, value: any): boolean {
-  return typeof props.units !== 'function' && key === 'metrics:area' && typeof value === 'number'
-}
-
 function preciseAreaValue(key: string | number, value: any): string | undefined {
-  if (!isDefaultAreaField(key, value)) {
+  if (typeof props.units === 'function' || key !== 'metrics:area' || typeof value !== 'number') {
     return undefined
   }
   return `${squareMetersFormatter.format(value)} m²`
@@ -75,7 +65,7 @@ function formattedValue(key: string | number, value: any): string {
     return value
   }
 
-  if (isDefaultAreaField(key, value)) {
+  if (typeof props.units !== 'function' && key === 'metrics:area') {
     return `${formatter.format(value / SQUARE_METERS_PER_HECTARE)} ha`
   }
 

--- a/src/components/PropertiesDisplay.vue
+++ b/src/components/PropertiesDisplay.vue
@@ -10,7 +10,23 @@
       {{ key }}:
     </v-list-item-title>
     <template #append>
+      <v-tooltip
+        v-if="preciseAreaValue(key, value)"
+        location="top"
+        :text="preciseAreaValue(key, value)"
+      >
+        <template #activator="{ props: tooltipProps }">
+          <div
+            v-bind="tooltipProps"
+            class="text-caption text-white text-right"
+            style="max-width: 120px; word-break: break-word"
+          >
+            {{ formattedValue(key, value) }}
+          </div>
+        </template>
+      </v-tooltip>
       <div
+        v-else
         class="text-caption text-white text-right"
         style="max-width: 120px; word-break: break-word"
       >
@@ -33,20 +49,39 @@ const propertiesWithoutGeometry = computed(() => {
   return propertiesWithoutGeometry
 })
 
+const SQUARE_METERS_PER_HECTARE = 10000
+
 const formatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 })
+
+const squareMetersFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 0,
+})
+
+function isDefaultAreaField(key: string | number, value: any): boolean {
+  return typeof props.units !== 'function' && key === 'metrics:area' && typeof value === 'number'
+}
+
+function preciseAreaValue(key: string | number, value: any): string | undefined {
+  if (!isDefaultAreaField(key, value)) {
+    return undefined
+  }
+  return `${squareMetersFormatter.format(value)} m²`
+}
 
 function formattedValue(key: string | number, value: any): string {
   if (typeof value !== 'number') {
     return value
   }
 
+  if (isDefaultAreaField(key, value)) {
+    return `${formatter.format(value / SQUARE_METERS_PER_HECTARE)} ha`
+  }
+
   const formatted = formatter.format(value)
   if (typeof props.units === 'function') {
     return `${formatted} ${props.units(key)}`
-  } else if (key === 'metrics:area') {
-    return `${formatted} m²`
   } else if (key === 'metrics:perimeter') {
     return `${formatted} m`
   }

--- a/src/components/PropertiesDisplay.vue
+++ b/src/components/PropertiesDisplay.vue
@@ -18,7 +18,7 @@
         <template #activator="{ props: tooltipProps }">
           <div
             v-bind="tooltipProps"
-            tabindex="0"
+            :tabindex="preciseAreaValue(key, value) ? 0 : -1"
             class="text-caption text-white text-right"
             style="max-width: 120px; word-break: break-word"
           >

--- a/src/composables/useGlobalFeedback.ts
+++ b/src/composables/useGlobalFeedback.ts
@@ -171,11 +171,11 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
   const zoomGateMessage = computed(() => {
     if (mapZoom.value < GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL) {
       const remaining = zoomLevelsRemaining(GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL)
-      return `Zoom in ${remaining} more level${remaining === 1 ? '' : 's'} to see fields and to give feedback.`
+      return `Zoom in ~${remaining} more level${remaining === 1 ? '' : 's'} to see fields and to give feedback.`
     }
     if (mapZoom.value < GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL) {
       const remaining = zoomLevelsRemaining(GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL)
-      return `Zoom in ${remaining} more level${remaining === 1 ? '' : 's'} to see all fields and to give feedback.`
+      return `Zoom in ~${remaining} more level${remaining === 1 ? '' : 's'} to see all fields and to give feedback.`
     }
     return ''
   })

--- a/src/composables/useGlobalFeedback.ts
+++ b/src/composables/useGlobalFeedback.ts
@@ -127,7 +127,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
   const { tileRating: tileRatingEndpoint, tellUsMore: tellUsMoreEndpoint } = getEndpoints()
 
   const sliderValue = ref<number>(1)
-  const hasInteractedWithSlider = ref(false)
+  const sliderTouched = ref(false)
   const detailsDialogOpen = ref(false)
   const tagsDialogOpen = ref(false)
   const selectedTags = ref<RatingTag[]>([])
@@ -163,8 +163,12 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     },
   })
 
+  const resetSliderTouched = () => {
+    sliderTouched.value = false
+  }
+
   watch(sliderValue, () => {
-    hasInteractedWithSlider.value = true
+    sliderTouched.value = true
   })
 
   const canProvideFeedback = computed(() => {
@@ -186,6 +190,10 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       return 'Zoom in more to see all fields and to give feedback.'
     }
     return ''
+  })
+
+  const canSubmitQuick = computed(() => {
+    return Boolean(selectedLevel.value) && sliderTouched.value
   })
 
   const canSubmitDetailed = computed(() => {
@@ -247,7 +255,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       return
     }
 
-    if (!selectedLevel.value || !hasInteractedWithSlider.value || !mapExtent.value) {
+    if (!canSubmitQuick.value || !mapExtent.value) {
       showError('Unable to submit feedback. Please try again.')
       return
     }
@@ -301,7 +309,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     if (ok) {
       showSuccess('Thanks for the feedback!')
       closeTagsDialog()
-      hasInteractedWithSlider.value = false
+      resetSliderTouched()
     }
   }
 
@@ -392,7 +400,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       closeDetailsDialog()
       resetDetailsForm()
       selectedTags.value = []
-      hasInteractedWithSlider.value = false
+      resetSliderTouched()
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Failed to submit detailed feedback.')
     } finally {
@@ -403,7 +411,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
   return {
     options: FEEDBACK_OPTIONS,
     sliderValue,
-    hasInteractedWithSlider,
+    sliderTouched,
     selectedLevel,
     detailsDialogOpen,
     detailsForm,
@@ -412,6 +420,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     canProvideFeedback,
     isMediumZoom,
     zoomGateMessage,
+    canSubmitQuick,
     canSubmitDetailed,
     isSubmittingQuick,
     isSubmittingDetails,

--- a/src/composables/useGlobalFeedback.ts
+++ b/src/composables/useGlobalFeedback.ts
@@ -127,7 +127,6 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
   const { tileRating: tileRatingEndpoint, tellUsMore: tellUsMoreEndpoint } = getEndpoints()
 
   const sliderValue = ref<number>(1)
-  const sliderTouched = ref(false)
   const detailsDialogOpen = ref(false)
   const tagsDialogOpen = ref(false)
   const selectedTags = ref<RatingTag[]>([])
@@ -163,37 +162,26 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     },
   })
 
-  const resetSliderTouched = () => {
-    sliderTouched.value = false
-  }
-
-  watch(sliderValue, () => {
-    sliderTouched.value = true
-  })
-
   const canProvideFeedback = computed(() => {
     return mapZoom.value >= GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL
   })
 
-  const isMediumZoom = computed(() => {
-    return (
-      mapZoom.value >= GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL &&
-      mapZoom.value < GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL
-    )
-  })
+  const zoomLevelsRemaining = (target: number) => Math.max(1, Math.ceil(target - mapZoom.value))
 
   const zoomGateMessage = computed(() => {
     if (mapZoom.value < GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL) {
-      return 'Zoom in to see fields and to give feedback.'
+      const remaining = zoomLevelsRemaining(GLOBAL_DATA_MAP_FIELD_START_ZOOM_LEVEL)
+      return `Zoom in ${remaining} more level${remaining === 1 ? '' : 's'} to see fields and to give feedback.`
     }
     if (mapZoom.value < GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL) {
-      return 'Zoom in more to see all fields and to give feedback.'
+      const remaining = zoomLevelsRemaining(GLOBAL_DATA_MAP_COMPLETE_ZOOM_LEVEL)
+      return `Zoom in ${remaining} more level${remaining === 1 ? '' : 's'} to see all fields and to give feedback.`
     }
     return ''
   })
 
   const canSubmitQuick = computed(() => {
-    return Boolean(selectedLevel.value) && sliderTouched.value
+    return Boolean(selectedLevel.value)
   })
 
   const canSubmitDetailed = computed(() => {
@@ -309,7 +297,6 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     if (ok) {
       showSuccess('Thanks for the feedback!')
       closeTagsDialog()
-      resetSliderTouched()
     }
   }
 
@@ -400,7 +387,6 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       closeDetailsDialog()
       resetDetailsForm()
       selectedTags.value = []
-      resetSliderTouched()
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Failed to submit detailed feedback.')
     } finally {
@@ -411,14 +397,12 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
   return {
     options: FEEDBACK_OPTIONS,
     sliderValue,
-    sliderTouched,
     selectedLevel,
     detailsDialogOpen,
     detailsForm,
     tagsDialogOpen,
     selectedTags,
     canProvideFeedback,
-    isMediumZoom,
     zoomGateMessage,
     canSubmitQuick,
     canSubmitDetailed,

--- a/src/composables/useGlobalFeedback.ts
+++ b/src/composables/useGlobalFeedback.ts
@@ -127,6 +127,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
   const { tileRating: tileRatingEndpoint, tellUsMore: tellUsMoreEndpoint } = getEndpoints()
 
   const sliderValue = ref<number>(1)
+  const hasInteractedWithSlider = ref(false)
   const detailsDialogOpen = ref(false)
   const tagsDialogOpen = ref(false)
   const selectedTags = ref<RatingTag[]>([])
@@ -160,6 +161,10 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     set: (rating: FeedbackRating | null) => {
       sliderValue.value = levelToSliderValue(rating)
     },
+  })
+
+  watch(sliderValue, () => {
+    hasInteractedWithSlider.value = true
   })
 
   const canProvideFeedback = computed(() => {
@@ -242,7 +247,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       return
     }
 
-    if (!selectedLevel.value || !mapExtent.value) {
+    if (!selectedLevel.value || !hasInteractedWithSlider.value || !mapExtent.value) {
       showError('Unable to submit feedback. Please try again.')
       return
     }
@@ -296,6 +301,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
     if (ok) {
       showSuccess('Thanks for the feedback!')
       closeTagsDialog()
+      hasInteractedWithSlider.value = false
     }
   }
 
@@ -348,9 +354,11 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       !detailsForm.value.qualityFeedback.trim() ||
       !detailsForm.value.useCase.trim()
     ) {
+      showError('Please fill out the required fields before submitting.')
       return
     }
     if (!isValidEmail(detailsForm.value.email)) {
+      showError('Please enter a valid email address, or leave it blank.')
       return
     }
     if (!mapExtent.value) {
@@ -384,6 +392,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
       closeDetailsDialog()
       resetDetailsForm()
       selectedTags.value = []
+      hasInteractedWithSlider.value = false
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Failed to submit detailed feedback.')
     } finally {
@@ -394,6 +403,7 @@ export default function useGlobalFeedback(mapRef: ShallowRef<Map | null>) {
   return {
     options: FEEDBACK_OPTIONS,
     sliderValue,
+    hasInteractedWithSlider,
     selectedLevel,
     detailsDialogOpen,
     detailsForm,


### PR DESCRIPTION
This PR resolves :

1. Area display improvement (#290): Changes field area measurement from raw square meters to hectares in the Field Properties popup, with precise m² values accessible via a keyboard-focusable tooltip.

2. Form validation feedback (#285): Adds visible error messages when the "Tell Us More" form validation fails (e.g. missing email).

3. Button labeling clarity (#284): Renames the quick-feedback button from "Submit"to "Continue" to better reflect that it opens a follow-up dialog rather than finalizing submission.

4. Contribute button relocated (#287): The "Contribute" button used to sit insidethe rating card next to "Continue," even though it opens an unrelated recruiting/partnership form. It's now a floating action button, independent of both the rating card and the settings panel, so it no longer reads as part of the rating flow.

5. Zoom-gate messaging (#286): The message shown before rating is enabled now says how many zoom levels remain (e.g. "Zoom in 3 more levels...") instead of a vague "zoom in more."


<img width="298" height="339" alt="Screenshot 2026-07-27 at 23 20 59" src="https://github.com/user-attachments/assets/609fc5a2-368d-44ab-a32b-48699e3f0720" />

<img width="435" height="308" alt="Screenshot 2026-07-28 at 16 34 42" src="https://github.com/user-attachments/assets/9e16bdfa-b8da-4798-9f1c-96da6c175608" />

<img width="462" height="112" alt="Screenshot 2026-07-28 at 16 35 21" src="https://github.com/user-attachments/assets/b303d94e-ff3d-4196-8c39-0877dd695c07" />
