### PR TITLE
Rename Custom mode title and relocate model badge (#295); fix About dialog checkbox auto-save (#298)

### DIFF
--- a/src/components/DataCabinet.vue
+++ b/src/components/DataCabinet.vue
@@ -9,7 +9,7 @@ import ProcessingPanel from './ProcessingPanel.vue'
 import GlobalDataPanel from './GlobalDataPanel.vue'
 
 const { searchStatus } = useSearch()
-const { modelTitle, settings } = useSettings()
+const { settings } = useSettings()
 const { isLayerLoading } = useMap()
 const { isConverting } = useDownloadGrid()
 
@@ -36,16 +36,7 @@ const toggleCollapsible = () => {
         >
         </v-icon>
         <span class="title text-white">
-          <template v-if="settings.mode === 'inference'">
-            Processing
-            <v-badge
-              v-if="modelTitle && !settings.expertMode"
-              inline
-              :content="`Model: ${modelTitle}`"
-              @click.stop="($refs.panel as typeof ProcessingPanel).openModelSelection()"
-              class="clickable-badge"
-            ></v-badge>
-          </template>
+          <template v-if="settings.mode === 'inference'"> Custom Processing </template>
           <template v-else> Global Predictions </template>
         </span>
       </div>
@@ -54,7 +45,6 @@ const toggleCollapsible = () => {
     <v-card-text v-show="isOpen" class="content">
       <ProcessingPanel
         v-if="settings.mode === 'inference'"
-        ref="panel"
         @work-state-changed="(v) => (isWorking = v)"
       />
       <GlobalDataPanel v-else />
@@ -63,12 +53,6 @@ const toggleCollapsible = () => {
 </template>
 
 <style scoped>
-.clickable-badge {
-  cursor: pointer;
-}
-.clickable-badge:hover :deep(.v-badge__badge) {
-  background-color: white;
-}
 .data-cabinet {
   left: 1rem;
   min-width: 350px;

--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -193,6 +193,17 @@ watch(
 
 const availableTiles = shallowRef<any[]>([])
 
+// Find the s2-grid layer's source among the map's layers
+function getS2GridSource(layers: any[]) {
+  const s2GridLayer = layers.find((layer) => {
+    if (layer.get('name') === 's2-grid') return true
+    if (layer.get('properties') && layer.get('properties').name === 's2-grid') return true
+    const source = (layer as any).getSource ? (layer as any).getSource() : null
+    return !!(source && source.getFeatures)
+  })
+  return s2GridLayer && (s2GridLayer as any).getSource?.()
+}
+
 // Load available S2 tiles from the map layer
 const loadAvailableTiles = () => {
   if (!map.value) {
@@ -200,15 +211,7 @@ const loadAvailableTiles = () => {
   }
 
   const layers = map.value.getLayers().getArray()
-
-  const s2GridLayer = layers.find((layer) => {
-    if (layer.get('name') === 's2-grid') return true
-    if (layer.get('properties') && layer.get('properties').name === 's2-grid') return true
-    const source = (layer as any).getSource ? (layer as any).getSource() : null
-    return !!(source && source.getFeatures)
-  })
-
-  const s2GridSource = s2GridLayer && (s2GridLayer as any).getSource?.()
+  const s2GridSource = getS2GridSource(layers)
 
   if (s2GridSource && s2GridSource.getFeatures) {
     const features = s2GridSource.getFeatures()
@@ -361,15 +364,10 @@ const loadMore = async () => {
 const handleTileSelected = (tileName: string) => {
   // Find the tile feature on the map and trigger the tile selection
   const layers = map.value!.getLayers().getArray()
-  const s2GridLayer = layers.find(
-    (layer) =>
-      layer.get('name') === 's2-grid' ||
-      (layer.get('properties') && layer.get('properties').name === 's2-grid') ||
-      ((layer as any).getSource && (layer as any).getSource().getFeatures),
-  )
+  const s2GridSource = getS2GridSource(layers)
 
-  if (s2GridLayer && (s2GridLayer as any).getSource) {
-    const features = (s2GridLayer as any).getSource().getFeatures()
+  if (s2GridSource) {
+    const features = s2GridSource.getFeatures()
     const targetFeature = features.find((f: any) => f.get('Name') === tileName)
 
     if (targetFeature) {
@@ -435,8 +433,9 @@ defineExpose({ openModelSelection })
       <template v-if="modelTitle && !settings.expertMode">
         <br />
         Using the ML model
-        <a href="#" @click.prevent="openModelSelection"
+        <a v-if="currentMgrsTileId" href="#" @click.prevent="openModelSelection"
           ><strong>{{ modelTitle }}</strong></a
+        ><strong v-else>{{ modelTitle }}</strong
         >.
       </template>
     </v-alert>

--- a/src/components/ProcessingPanel.vue
+++ b/src/components/ProcessingPanel.vue
@@ -201,15 +201,17 @@ const loadAvailableTiles = () => {
 
   const layers = map.value.getLayers().getArray()
 
-  const s2GridLayer = layers.find(
-    (layer) =>
-      layer.get('name') === 's2-grid' ||
-      (layer.get('properties') && layer.get('properties').name === 's2-grid') ||
-      ((layer as any).getSource && (layer as any).getSource().getFeatures),
-  )
+  const s2GridLayer = layers.find((layer) => {
+    if (layer.get('name') === 's2-grid') return true
+    if (layer.get('properties') && layer.get('properties').name === 's2-grid') return true
+    const source = (layer as any).getSource ? (layer as any).getSource() : null
+    return !!(source && source.getFeatures)
+  })
 
-  if (s2GridLayer && (s2GridLayer as any).getSource) {
-    const features = (s2GridLayer as any).getSource().getFeatures()
+  const s2GridSource = s2GridLayer && (s2GridLayer as any).getSource?.()
+
+  if (s2GridSource && s2GridSource.getFeatures) {
+    const features = s2GridSource.getFeatures()
 
     availableTiles.value = features
       .map((feature: any) => ({
@@ -429,6 +431,13 @@ defineExpose({ openModelSelection })
       <template v-else>
         You are in <strong>small area mode</strong>. The processing usually takes less than 30
         seconds. Use this for a quick preview on smaller areas.
+      </template>
+      <template v-if="modelTitle && !settings.expertMode">
+        <br />
+        Using the ML model
+        <a href="#" @click.prevent="openModelSelection"
+          ><strong>{{ modelTitle }}</strong></a
+        >.
       </template>
     </v-alert>
 

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -9,9 +9,15 @@ const ftwAboutDialogShown = localStorage.getItem('ftw-about-dialog-shown') !== '
 const aboutDialog = ref(ftwAboutDialogShown)
 const dontShowAgain = ref(!ftwAboutDialogShown)
 
-watch(dontShowAgain, (newValue) => {
-  localStorage.setItem('ftw-about-dialog-shown', String(newValue))
-})
+function openAboutDialog() {
+  dontShowAgain.value = localStorage.getItem('ftw-about-dialog-shown') === 'true'
+  aboutDialog.value = true
+}
+
+function closeAboutDialog() {
+  localStorage.setItem('ftw-about-dialog-shown', String(dontShowAgain.value))
+  aboutDialog.value = false
+}
 
 const modeValue = ref(0)
 watch(
@@ -37,7 +43,7 @@ function setModeValue(newValue: number) {
         src="https://fieldsofthe.world/static/images/brand/logos/ftw-logo-light.svg"
         alt="Fields of The World (FTW) Explorer"
         class="logo"
-        @click="aboutDialog = true"
+        @click="openAboutDialog"
       />
       <v-card variant="outlined" rounded="lg" class="switch">
         <span class="switch-label">Mode</span>
@@ -78,7 +84,7 @@ function setModeValue(newValue: number) {
         <v-card-actions>
           <v-checkbox-btn v-model="dontShowAgain" label="Don't show again"></v-checkbox-btn>
           <v-spacer></v-spacer>
-          <v-btn variant="flat" color="primary" text="Ok" @click="aboutDialog = false"></v-btn>
+          <v-btn variant="flat" color="primary" text="Ok" @click="closeAboutDialog"></v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -5,12 +5,13 @@ import useSettings from '../composables/useSettings'
 
 const { settings, availableModes } = useSettings()
 
-const ftwAboutDialogShown = localStorage.getItem('ftw-about-dialog-shown') !== 'true'
-const aboutDialog = ref(ftwAboutDialogShown)
-const dontShowAgain = ref(!ftwAboutDialogShown)
+const getDontShowAgainStored = () => localStorage.getItem('ftw-about-dialog-shown') === 'true'
+
+const dontShowAgain = ref(getDontShowAgainStored())
+const aboutDialog = ref(!dontShowAgain.value)
 
 function openAboutDialog() {
-  dontShowAgain.value = localStorage.getItem('ftw-about-dialog-shown') === 'true'
+  dontShowAgain.value = getDontShowAgainStored()
   aboutDialog.value = true
 }
 


### PR DESCRIPTION
This PR resolves: 

1. Renames the "Processing" panel title to "Custom Processing" so it matches the "Custom" mode toggle label; the active ML model name is now shown inline in the panel body instead of a title badge, with clearer "Using the ML model X" wording.
<img width="551" height="320" alt="Screenshot 2026-08-04 at 17 07 19" src="https://github.com/user-attachments/assets/b661e8c2-5d9a-4533-bdde-8038b69d62df" />


2. The About dialog's "Don't show again" checkbox no longer writes to localStorage on every toggle. It only saves when the dialog is explicitly closed via Ok, and reopens reflecting the last saved state