### PR TITLE
Add threshold warning, download format radios, and welcome dialog CTAs (#289, #299, #281, #280)

### DIFF
--- a/src/components/GeocodingSearch.vue
+++ b/src/components/GeocodingSearch.vue
@@ -2,11 +2,18 @@
 import { ref, shallowRef, watch } from 'vue'
 import { debounce } from 'vuetify/lib/util/helpers.mjs'
 import type { PlaceResult } from '../composables/useAreaOfInterest'
+import useLocationSearchFocus from '../composables/useLocationSearchFocus'
 import { mdiInformationOutline } from '@mdi/js'
 
 const emit = defineEmits<{
   (e: 'location-selected', place: PlaceResult): void
 }>()
+
+const { focusRequestId } = useLocationSearchFocus()
+const searchField = ref<{ focus: () => void } | null>(null)
+watch(focusRequestId, () => {
+  searchField.value?.focus()
+})
 
 const isLoadingPlaces = ref(false)
 const placeSearch = ref('')
@@ -67,6 +74,7 @@ const onLocationSelected = (item: { value: PlaceResult; title: string } | null) 
 <template>
   <div class="d-flex align-center mb-2 ga-2">
     <v-autocomplete
+      ref="searchField"
       @update:model-value="onLocationSelected"
       v-model:search="placeSearch"
       :loading="isLoadingPlaces"

--- a/src/components/GlobalDataPanel.vue
+++ b/src/components/GlobalDataPanel.vue
@@ -165,7 +165,9 @@ const handleLocationSelected = (place: PlaceResult) => {
             <v-radio label="GeoParquet" value="parquet"></v-radio>
             <v-radio label="GeoJSON" value="json"></v-radio>
           </v-radio-group>
-          <p class="text-caption text-medium-emphasis mb-1">Click any grid cell to download.</p>
+          <p class="text-caption text-medium-emphasis mt-2 mb-1">
+            Click any grid cell on the map to download.
+          </p>
         </template>
         <h3 class="group legend">
           Legend

--- a/src/components/GlobalDataPanel.vue
+++ b/src/components/GlobalDataPanel.vue
@@ -12,12 +12,16 @@ import { transformExtent } from 'ol/proj'
 import GeocodingSearch from './GeocodingSearch.vue'
 import MapLegend from './MapLegend.vue'
 
-const { settings } = useSettings()
+const { settings, defaultSettings } = useSettings()
 const { map } = useMap()
 
 const basemapYearMismatch = computed(
   () => settings.value.year !== getEffectiveCloudlessYear(settings.value.year),
 )
+const thresholdMayHideFields = computed(() => settings.value.threshold >= 90)
+const resetThreshold = () => {
+  settings.value.threshold = defaultSettings.threshold
+}
 const { fitToExtent } = useAreaOfInterest()
 const { showError } = useNotifier()
 const { downloadFormat } = useDownloadGrid()
@@ -105,6 +109,16 @@ const handleLocationSelected = (place: PlaceResult) => {
           thumb-color="teal"
           hide-details
         />
+        <v-alert
+          v-if="thresholdMayHideFields"
+          type="warning"
+          variant="tonal"
+          density="compact"
+          class="mt-2 note"
+        >
+          A high confidence threshold may hide most or all fields in this area.
+          <v-btn @click="resetThreshold" size="small" class="mt-2"> Reset threshold </v-btn>
+        </v-alert>
         <h3 class="group">Opacity: {{ settings.opacity }}%</h3>
         <v-slider
           v-model.number="settings.opacity"
@@ -146,19 +160,13 @@ const handleLocationSelected = (place: PlaceResult) => {
           label="Show download grid"
           class="mb-1"
         />
-        <v-switch
-          v-if="settings.downloads"
-          v-model="downloadFormat"
-          color="teal"
-          density="compact"
-          hide-details
-          label="GeoJSON"
-          true-value="json"
-          false-value="parquet"
-          class="mb-1"
-        >
-          <template #prepend> GeoParquet </template>
-        </v-switch>
+        <template v-if="settings.downloads">
+          <v-radio-group v-model="downloadFormat" density="compact" hide-details inline>
+            <v-radio label="GeoParquet" value="parquet"></v-radio>
+            <v-radio label="GeoJSON" value="json"></v-radio>
+          </v-radio-group>
+          <p class="text-caption text-medium-emphasis mb-1">Click any grid cell to download.</p>
+        </template>
         <h3 class="group legend">
           Legend
           <v-menu open-on-hover :close-on-content-click="false" max-width="360">

--- a/src/components/MapComponent.vue
+++ b/src/components/MapComponent.vue
@@ -149,7 +149,6 @@ defineExpose({
     <GlobalFeedbackWidget v-if="map && settings.mode === 'global'" />
 
     <v-btn
-      v-if="settings.mode === 'global'"
       class="contribute-fab"
       icon
       color="teal"
@@ -162,7 +161,6 @@ defineExpose({
     </v-btn>
 
     <GlobalContributeModal
-      v-if="settings.mode === 'global'"
       v-model="contributeDialogOpen"
       :contribute-form="contributeForm"
       :contribution-options="CONTRIBUTION_OPTIONS"

--- a/src/composables/useLocationSearchFocus.ts
+++ b/src/composables/useLocationSearchFocus.ts
@@ -1,0 +1,16 @@
+import { ref } from 'vue'
+
+// Incrementing counter (rather than a boolean) so a watcher fires every time
+// focus is requested, even if the previous request never got reset.
+const focusRequestId = ref(0)
+
+export default function useLocationSearchFocus() {
+  const requestLocationSearchFocus = () => {
+    focusRequestId.value++
+  }
+
+  return {
+    focusRequestId,
+    requestLocationSearchFocus,
+  }
+}

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -22,11 +22,21 @@ function closeAboutDialog() {
   aboutDialog.value = false
 }
 
+let focusTimeout: ReturnType<typeof setTimeout> | null = null
 watch(aboutDialog, (isOpen, wasOpen) => {
+  if (focusTimeout) {
+    clearTimeout(focusTimeout)
+    focusTimeout = null
+  }
   if (!isOpen && wasOpen) {
     // Wait out Vuetify's dialog close transition + focus-restore, or our
     // focus call gets immediately overridden by it.
-    setTimeout(requestLocationSearchFocus, 300)
+    focusTimeout = setTimeout(() => {
+      focusTimeout = null
+      if (!aboutDialog.value) {
+        requestLocationSearchFocus()
+      }
+    }, 300)
   }
 })
 

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -2,8 +2,10 @@
 import MapComponent from '../components/MapComponent.vue'
 import { ref, watch } from 'vue'
 import useSettings from '../composables/useSettings'
+import useLocationSearchFocus from '../composables/useLocationSearchFocus'
 
 const { settings, availableModes } = useSettings()
+const { requestLocationSearchFocus } = useLocationSearchFocus()
 
 const getDontShowAgainStored = () => localStorage.getItem('ftw-about-dialog-shown') === 'true'
 
@@ -19,6 +21,14 @@ function closeAboutDialog() {
   localStorage.setItem('ftw-about-dialog-shown', String(dontShowAgain.value))
   aboutDialog.value = false
 }
+
+watch(aboutDialog, (isOpen, wasOpen) => {
+  if (!isOpen && wasOpen) {
+    // Wait out Vuetify's dialog close transition + focus-restore, or our
+    // focus call gets immediately overridden by it.
+    setTimeout(requestLocationSearchFocus, 300)
+  }
+})
 
 const modeValue = ref(0)
 watch(
@@ -73,14 +83,20 @@ function setModeValue(newValue: number) {
           <p class="mb-2">This app has two modes, switched at the top of the screen:</p>
           <ul class="ps-5 mb-0">
             <li class="mb-2">
-              <strong>Global:</strong> Browse pre-computed global field boundaries for 2024 and
-              2025. Zoom in to explore individual fields, or download a 1° tile as GeoParquet.
+              <p class="mb-1">
+                <strong>Global:</strong> Browse pre-computed global field boundaries for 2024 and
+                2025. Zoom in to explore individual fields, or download a 1° tile as GeoParquet.
+              </p>
+              <p class="mb-0">
+                Rate the field boundaries you see — your feedback helps improve the model.
+              </p>
             </li>
             <li>
               <strong>Custom:</strong> Run the FTW model on-demand over an area you choose, using
               Sentinel-2 Level 2A imagery.
             </li>
           </ul>
+          <p class="mt-3 mb-0">Ready to explore? Try searching for a region.</p>
         </v-card-text>
         <v-card-actions>
           <v-checkbox-btn v-model="dontShowAgain" label="Don't show again"></v-checkbox-btn>


### PR DESCRIPTION
Stacked on #300 

1. Confidence threshold ≥90% now shows a warning with a "Reset threshold" button (#289 ).
2. Download format switch replaced with clear GeoParquet/GeoJSON radio buttons + inline caption (#299).
3. Welcome dialog now mentions rating field boundaries (#281) and ends with a CTA to search for a region, auto-focusing the location search field on close (#280).
4. Also shows the Contribute button/modal in Custom mode, not just Global (not a filed issue).
<img width="670" height="762" alt="image" src="https://github.com/user-attachments/assets/a34cd917-4586-4566-b47a-206f1524679f" />
<img width="404" height="157" alt="Screenshot 2026-08-05 at 12 13 52" src="https://github.com/user-attachments/assets/6ac07b7e-11d1-4433-9590-8030413e8a97" />

<img width="610" height="403" alt="Screenshot 2026-08-05 at 12 13 35" src="https://github.com/user-attachments/assets/6297d453-7e82-431a-b9e3-099470ac45b0" />

