### PR TITLE
Condense global feedback widget: narrow card and center Continue button

### DIFF
--- a/src/components/GlobalFeedbackWidget.vue
+++ b/src/components/GlobalFeedbackWidget.vue
@@ -113,7 +113,7 @@ const sliderLabels = computed(() => {
   bottom: 1rem;
   transform: translateX(-50%);
   z-index: 1001;
-  width: min(90vw, 350px);
+  width: min(90vw, 300px);
 }
 
 .feedback-card {
@@ -164,7 +164,7 @@ const sliderLabels = computed(() => {
 
 .feedback-actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
   gap: 0.35rem;
   margin-top: 1.2rem;
 }


### PR DESCRIPTION
Shrinks the card footprint on the map and removes the empty space next to the Continue button, per feedback on PR #301.